### PR TITLE
Re work env and commands

### DIFF
--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -24,12 +23,6 @@ Change the current directory:
     absolute or relative path. The format and semantics of the path string is
     determined by the underlying operating system.
 ";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -36,13 +36,14 @@ Change the current directory:
             {
                 //print the current directory
                 string dir = System.IO.Directory.GetCurrentDirectory();
-                control.AddRenderItem(new InfoItem(dir, control.DrawSettings.Font, env));
+                control.AddRenderItem(
+                    new InfoItem(dir, control.DrawSettings.Font));
             }
             else if (!System.IO.Directory.Exists(args[1]))
             {
                 control.AddRenderItem(
                     new ErrorItem(input, "Parameter must be a folder name",
-                        control.DrawSettings.Font, LBrush.Red, env,
+                        control.DrawSettings.Font, LBrush.Red,
                         input.IndexOf(args[1])));
             }
             else
@@ -56,14 +57,14 @@ Change the current directory:
                     control.AddRenderItem(
                         new InfoItem(
                             $"Directory changed to \"{dir}\"",
-                            control.DrawSettings.Font, env));
+                            control.DrawSettings.Font));
                 }
                 catch (Exception e)
                 {
                     control.AddRenderItem(
                         new ErrorItem(
                             input, $"There was an error: \r\n{e}",
-                            control.DrawSettings.Font, LBrush.Red, env));
+                            control.DrawSettings.Font, LBrush.Red));
                 }
             }
         }

--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -36,11 +36,11 @@ Change the current directory:
             {
                 //print the current directory
                 string dir = System.IO.Directory.GetCurrentDirectory();
-                env.AddRenderItem(new InfoItem(dir, env.Font, env));
+                control.AddRenderItem(new InfoItem(dir, env.Font, env));
             }
             else if (!System.IO.Directory.Exists(args[1]))
             {
-                env.AddRenderItem(
+                control.AddRenderItem(
                     new ErrorItem(input, "Parameter must be a folder name",
                         env.Font, LBrush.Red, env, input.IndexOf(args[1])));
             }
@@ -52,14 +52,14 @@ Change the current directory:
                 try
                 {
                     System.IO.Directory.SetCurrentDirectory(dir);
-                    env.AddRenderItem(
+                    control.AddRenderItem(
                         new InfoItem(
                             "Directory changed to \"" + dir + "\"",
                             env.Font, env));
                 }
                 catch (Exception e)
                 {
-                    env.AddRenderItem(
+                    control.AddRenderItem(
                         new ErrorItem(
                             input, "There was an error: \r\n" + e.ToString(),
                             env.Font, LBrush.Red, env));

--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
@@ -24,13 +25,14 @@ Change the current directory:
     determined by the underlying operating system.
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             if (args.Length <= 1)
             {

--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -29,7 +29,8 @@ Change the current directory:
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             if (args.Length <= 1)
             {

--- a/Commands/CdCommand.cs
+++ b/Commands/CdCommand.cs
@@ -36,13 +36,14 @@ Change the current directory:
             {
                 //print the current directory
                 string dir = System.IO.Directory.GetCurrentDirectory();
-                control.AddRenderItem(new InfoItem(dir, env.Font, env));
+                control.AddRenderItem(new InfoItem(dir, control.DrawSettings.Font, env));
             }
             else if (!System.IO.Directory.Exists(args[1]))
             {
                 control.AddRenderItem(
                     new ErrorItem(input, "Parameter must be a folder name",
-                        env.Font, LBrush.Red, env, input.IndexOf(args[1])));
+                        control.DrawSettings.Font, LBrush.Red, env,
+                        input.IndexOf(args[1])));
             }
             else
             {
@@ -54,15 +55,15 @@ Change the current directory:
                     System.IO.Directory.SetCurrentDirectory(dir);
                     control.AddRenderItem(
                         new InfoItem(
-                            "Directory changed to \"" + dir + "\"",
-                            env.Font, env));
+                            $"Directory changed to \"{dir}\"",
+                            control.DrawSettings.Font, env));
                 }
                 catch (Exception e)
                 {
                     control.AddRenderItem(
                         new ErrorItem(
-                            input, "There was an error: \r\n" + e.ToString(),
-                            env.Font, LBrush.Red, env));
+                            input, $"There was an error: \r\n{e}",
+                            control.DrawSettings.Font, LBrush.Red, env));
                 }
             }
         }

--- a/Commands/ClearCommand.cs
+++ b/Commands/ClearCommand.cs
@@ -1,4 +1,3 @@
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -20,12 +19,6 @@ Clear command history:
 Clear both output and history:
   clear all
 ";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/Commands/ClearCommand.cs
+++ b/Commands/ClearCommand.cs
@@ -1,4 +1,5 @@
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
@@ -20,13 +21,14 @@ Clear both output and history:
   clear all
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             if (args.Length > 1)
             {

--- a/Commands/ClearCommand.cs
+++ b/Commands/ClearCommand.cs
@@ -37,16 +37,16 @@ Clear both output and history:
                 else if (args[1].ToLower() == "all")
                 {
                     ClearHistory(env, control);
-                    ClearOutput(env, control);
+                    ClearOutput(control);
                 }
                 else
                 {
-                    ClearOutput(env, control);
+                    ClearOutput(control);
                 }
             }
             else
             {
-                ClearOutput(env, control);
+                ClearOutput(control);
             }
         }
     }

--- a/Commands/ClearCommand.cs
+++ b/Commands/ClearCommand.cs
@@ -25,27 +25,28 @@ Clear both output and history:
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             if (args.Length > 1)
             {
                 if (args[1].ToLower() == "history")
                 {
-                    ClearHistory(env);
+                    ClearHistory(env, control);
                 }
                 else if (args[1].ToLower() == "all")
                 {
-                    ClearHistory(env);
-                    ClearOutput(env);
+                    ClearHistory(env, control);
+                    ClearOutput(env, control);
                 }
                 else
                 {
-                    ClearOutput(env);
+                    ClearOutput(env, control);
                 }
             }
             else
             {
-                ClearOutput(env);
+                ClearOutput(env, control);
             }
         }
     }

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -55,7 +55,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 control.RemoveRenderItem(item);
             }
 
-            env.ClearCanvas();
+            control.ClearCanvas();
         }
     }
 }

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -6,7 +6,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
 {
     public abstract class Command : Solus.Commands.Command
     {
-        public abstract void Execute(string input, string[] args, LigraEnvironment env);
+        public abstract void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control);
 
         public virtual string GetInputLabel(string input, LigraEnvironment env)
         {
@@ -38,14 +39,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
             commands["func_assign"] = FuncAssignCommand.Value;
         }
 
-        public static void ClearHistory(LigraEnvironment env)
+        public static void ClearHistory(LigraEnvironment env, ILigraUI control)
         {
             env.History.Clear();
             env.CurrentHistoryIndex = -1;
             env.AddRenderItem(new InfoItem("History cleared", env.Font, env));
         }
 
-        public static void ClearOutput(LigraEnvironment env)
+        public static void ClearOutput(LigraEnvironment env, ILigraUI control)
         {
             var items = env.RenderItems.ToArray();
             foreach (var item in items)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -45,7 +45,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.History.Clear();
             control.CurrentHistoryIndex = -1;
             control.AddRenderItem(
-                new InfoItem("History cleared", control.DrawSettings.Font, env));
+                new InfoItem("History cleared", control.DrawSettings.Font));
         }
 
         public static void ClearOutput(ILigraUI control)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -51,7 +51,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var items = env.RenderItems.ToArray();
             foreach (var item in items)
             {
-                env.Control.RemoveRenderItem(item);
+                control.RemoveRenderItem(item);
             }
 
             env.ClearCanvas();

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -41,8 +41,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public static void ClearHistory(LigraEnvironment env, ILigraUI control)
         {
-            env.History.Clear();
-            env.CurrentHistoryIndex = -1;
+            control.History.Clear();
+            control.CurrentHistoryIndex = -1;
             control.AddRenderItem(
                 new InfoItem("History cleared", env.Font, env));
         }

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -44,7 +44,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.History.Clear();
             control.CurrentHistoryIndex = -1;
             control.AddRenderItem(
-                new InfoItem("History cleared", env.Font, env));
+                new InfoItem("History cleared", control.DrawSettings.Font, env));
         }
 
         public static void ClearOutput(LigraEnvironment env, ILigraUI control)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -9,7 +9,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public abstract void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control);
 
-        public virtual string GetInputLabel(string input, LigraEnvironment env)
+        public virtual string GetInputLabel(string input, LigraEnvironment env,
+            ILigraUI control)
         {
             return string.Format("$ {0}", input);
         }

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 new InfoItem("History cleared", control.DrawSettings.Font, env));
         }
 
-        public static void ClearOutput(LigraEnvironment env, ILigraUI control)
+        public static void ClearOutput(ILigraUI control)
         {
             var items = control.RenderItems.ToArray();
             foreach (var item in items)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -18,6 +18,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public abstract void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control);
 
+        public virtual bool ModifiesEnvironment => false;
+
         public virtual string GetInputLabel(string input, LigraEnvironment env,
             ICommandData data, ILigraUI control)
         {

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -43,7 +43,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
         {
             env.History.Clear();
             env.CurrentHistoryIndex = -1;
-            env.AddRenderItem(new InfoItem("History cleared", env.Font, env));
+            control.AddRenderItem(
+                new InfoItem("History cleared", env.Font, env));
         }
 
         public static void ClearOutput(LigraEnvironment env, ILigraUI control)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -1,17 +1,25 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
+using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
     public abstract class Command : Solus.Commands.Command
     {
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
+        {
+            throw new NotImplementedException();
+        }
+
         public abstract void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control);
 
         public virtual string GetInputLabel(string input, LigraEnvironment env,
-            ILigraUI control)
+            ICommandData data, ILigraUI control)
         {
             return string.Format("$ {0}", input);
         }
@@ -59,6 +67,52 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             control.ClearCanvas();
         }
+
+        public static implicit operator SimpleCommandData(Command command)
+        {
+            return new SimpleCommandData(command);
+        }
+    }
+
+    public class SimpleCommandData : ICommandData
+    {
+        public SimpleCommandData(Command command)
+        {
+            Command = command;
+        }
+
+        public Solus.Commands.Command Command { get; }
+    }
+
+    public static class CommandHelper
+    {
+        public static void Execute(this Solus.Commands.Command command,
+            string input, string[] args, LigraEnvironment env,
+            ICommandData data, ILigraUI control)
+        {
+            ((Command) command).Execute(input, args, env, data, control);
+        }
+
+        public static void Execute(this ICommandData data,
+            string input, string[] args, LigraEnvironment env,
+            ILigraUI control)
+        {
+            ((Command) data.Command).Execute(input, args, env, data, control);
+        }
+
+        public static string GetInputLabel(
+            this Solus.Commands.Command command, string input,
+            LigraEnvironment env, ICommandData data, ILigraUI control)
+        {
+            return ((Command) command).GetInputLabel(input, env, data,
+                control);
+        }
+
+        public static string GetInputLabel( this ICommandData data,
+            string input, LigraEnvironment env, ILigraUI control)
+        {
+            return ((Command) data.Command).GetInputLabel(input, env, data,
+                control);
+        }
     }
 }
-

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
     public abstract class Command : Solus.Commands.Command
     {
         public abstract void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control);
+            LigraEnvironment env, ICommandData data, ILigraUI control);
 
         public virtual string GetInputLabel(string input, LigraEnvironment env,
             ILigraUI control)

--- a/Commands/Command.cs
+++ b/Commands/Command.cs
@@ -48,7 +48,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public static void ClearOutput(LigraEnvironment env, ILigraUI control)
         {
-            var items = env.RenderItems.ToArray();
+            var items = control.RenderItems.ToArray();
             foreach (var item in items)
             {
                 control.RemoveRenderItem(item);

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -18,12 +17,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
   var
     The name of a variable previously defined via ""<var> := <expr>"".
 ";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -18,6 +18,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
     The name of a variable previously defined via ""<var> := <expr>"".
 ";
 
+        public override bool ModifiesEnvironment => true;
+
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
@@ -18,13 +19,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
     The name of a variable previously defined via ""<var> := <expr>"".
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             if (args.Length > 1)
             {
@@ -33,7 +35,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 int i;
                 for (i = 1; i < args.Length; i++)
                 {
-                    if (!env.Variables.ContainsKey(args[i]))
+                    if (!env.ContainsVariable(args[i]))
                     {
                         unknownVars.Add(args[i]);
                     }
@@ -55,7 +57,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 {
                     for (i = 1; i < args.Length; i++)
                     {
-                        env.Variables.Remove(args[i]);
+                        env.RemoveVariable(args[i]);
                     }
 
                     control.AddRenderItem(

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -47,7 +47,9 @@ namespace MetaphysicsIndustries.Ligra.Commands
                         error += s + "\r\n";
                     }
 
-                    env.AddRenderItem(new ErrorItem(input, error, env.Font, LBrush.Red, env, input.IndexOf(args[0])));
+                    control.AddRenderItem(
+                        new ErrorItem(input, error, env.Font, LBrush.Red, env,
+                            input.IndexOf(args[0])));
                 }
                 else
                 {
@@ -56,13 +58,17 @@ namespace MetaphysicsIndustries.Ligra.Commands
                         env.Variables.Remove(args[i]);
                     }
 
-                    env.AddRenderItem(new InfoItem("The variables were deleted successfully.", env.Font, env));
+                    control.AddRenderItem(
+                        new InfoItem(
+                            "The variables were deleted successfully.",
+                            env.Font, env));
                 }
             }
             else
             {
-                env.AddRenderItem(new ErrorItem(input, "Must specify variables to delete", env.Font, LBrush.Red, env,
-                    input.IndexOf(args[0])));
+                control.AddRenderItem(
+                    new ErrorItem(input, "Must specify variables to delete",
+                        env.Font, LBrush.Red, env, input.IndexOf(args[0])));
             }
         }
     }

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -23,7 +23,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             if (args.Length > 1)
             {

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -48,8 +48,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     }
 
                     control.AddRenderItem(
-                        new ErrorItem(input, error, env.Font, LBrush.Red, env,
-                            input.IndexOf(args[0])));
+                        new ErrorItem(input, error, control.DrawSettings.Font,
+                            LBrush.Red, env, input.IndexOf(args[0])));
                 }
                 else
                 {
@@ -61,14 +61,15 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     control.AddRenderItem(
                         new InfoItem(
                             "The variables were deleted successfully.",
-                            env.Font, env));
+                            control.DrawSettings.Font, env));
                 }
             }
             else
             {
                 control.AddRenderItem(
                     new ErrorItem(input, "Must specify variables to delete",
-                        env.Font, LBrush.Red, env, input.IndexOf(args[0])));
+                        control.DrawSettings.Font, LBrush.Red, env,
+                        input.IndexOf(args[0])));
             }
         }
     }

--- a/Commands/DeleteCommand.cs
+++ b/Commands/DeleteCommand.cs
@@ -49,7 +49,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
                     control.AddRenderItem(
                         new ErrorItem(input, error, control.DrawSettings.Font,
-                            LBrush.Red, env, input.IndexOf(args[0])));
+                            LBrush.Red, input.IndexOf(args[0])));
                 }
                 else
                 {
@@ -61,14 +61,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     control.AddRenderItem(
                         new InfoItem(
                             "The variables were deleted successfully.",
-                            control.DrawSettings.Font, env));
+                            control.DrawSettings.Font));
                 }
             }
             else
             {
                 control.AddRenderItem(
                     new ErrorItem(input, "Must specify variables to delete",
-                        control.DrawSettings.Font, LBrush.Red, env,
+                        control.DrawSettings.Font, LBrush.Red,
                         input.IndexOf(args[0])));
             }
         }

--- a/Commands/Example2Command.cs
+++ b/Commands/Example2Command.cs
@@ -1,4 +1,5 @@
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -11,19 +12,20 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string DocString =>
             @"example2 - Show some of the things that Ligra can do";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
 
-            if (!env.Variables.ContainsKey("x")) env.Variables.Add("x", new Literal(0));
-            if (!env.Variables.ContainsKey("y")) env.Variables.Add("y", new Literal(0));
-
-            Expression expr;
+            if (!env.ContainsVariable("x")) env.SetVariable("x",
+                new Literal(0));
+            if (!env.ContainsVariable("y")) env.SetVariable("y",
+                new Literal(0));
 
             var parser = new LigraParser();
 //            expr = parser.GetExpression("unitstep((x*x+y*y)^0.5+2*(sin(t)-1))*cos(5*y+2*t)", env);
@@ -34,9 +36,12 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var input3 =
                 "cos_taylor(x, n, sign) := if (n-8, sign * (x ^ n) / factorial(n) + cos_taylor(x, n+2, -sign), 0)";
             var input4 = "cos2(x) := cos_taylor(x, 0, 1)";
-            parser.GetCommands(input2, env)[0].Execute(input2, null, env, control);
-            parser.GetCommands(input3, env)[0].Execute(input3, null, env, control);
-            parser.GetCommands(input4, env)[0].Execute(input4, null, env, control);
+            parser.GetCommands(input2, env)[0].Execute(input2, null, env,
+             null, control);
+            parser.GetCommands(input3, env)[0].Execute(input3, null, env,
+             null, control);
+            parser.GetCommands(input4, env)[0].Execute(input4, null, env,
+             null, control);
         }
     }
 }

--- a/Commands/Example2Command.cs
+++ b/Commands/Example2Command.cs
@@ -16,7 +16,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
 
             if (!env.Variables.ContainsKey("x")) env.Variables.Add("x", new Literal(0));
@@ -33,9 +34,9 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var input3 =
                 "cos_taylor(x, n, sign) := if (n-8, sign * (x ^ n) / factorial(n) + cos_taylor(x, n+2, -sign), 0)";
             var input4 = "cos2(x) := cos_taylor(x, 0, 1)";
-            parser.GetCommands(input2, env)[0].Execute(input2, null, env);
-            parser.GetCommands(input3, env)[0].Execute(input3, null, env);
-            parser.GetCommands(input4, env)[0].Execute(input4, null, env);
+            parser.GetCommands(input2, env)[0].Execute(input2, null, env, control);
+            parser.GetCommands(input3, env)[0].Execute(input3, null, env, control);
+            parser.GetCommands(input4, env)[0].Execute(input4, null, env, control);
         }
     }
 }

--- a/Commands/Example2Command.cs
+++ b/Commands/Example2Command.cs
@@ -1,4 +1,3 @@
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -11,12 +10,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string Name => "example2";
         public override string DocString =>
             @"example2 - Show some of the things that Ligra can do";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
@@ -37,11 +30,11 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 "cos_taylor(x, n, sign) := if (n-8, sign * (x ^ n) / factorial(n) + cos_taylor(x, n+2, -sign), 0)";
             var input4 = "cos2(x) := cos_taylor(x, 0, 1)";
             parser.GetCommands(input2, env)[0].Execute(input2, null, env,
-             null, control);
+                control);
             parser.GetCommands(input3, env)[0].Execute(input3, null, env,
-             null, control);
+                control);
             parser.GetCommands(input4, env)[0].Execute(input4, null, env,
-             null, control);
+                control);
         }
     }
 }

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Transformers;
@@ -15,21 +16,26 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string DocString =>
             @"example - Show some of the things that Ligra can do";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             var f = control.DrawSettings.Font;
             var p = LPen.Blue;
 
-            if (!env.Variables.ContainsKey("x")) env.Variables.Add("x", new Literal(0));
-            if (!env.Variables.ContainsKey("y")) env.Variables.Add("y", new Literal(0));
-            if (!env.Variables.ContainsKey("mu")) env.Variables.Add("mu", new Literal(0));
-            if (!env.Variables.ContainsKey("sigma")) env.Variables.Add("sigma", new Literal(0));
+            if (!env.ContainsVariable("x"))
+                env.SetVariable("x", new Literal(0));
+            if (!env.ContainsVariable("y"))
+                env.SetVariable("y", new Literal(0));
+            if (!env.ContainsVariable("mu"))
+                env.SetVariable("mu", new Literal(0));
+            if (!env.ContainsVariable("sigma"))
+                env.SetVariable("sigma", new Literal(0));
 
             Expression expr;
 
@@ -89,8 +95,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 p,
                 f));
 
-            env.Variables["mu"] = new Literal(0.5f);
-            env.Variables["sigma"] = new Literal(0.2f);
+            env.SetVariable("mu", new Literal(0.5f));
+            env.SetVariable("sigma", new Literal(0.2f));
 
             expr =
                 new FunctionCall(

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -33,20 +33,23 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             Expression expr;
 
-            env.AddRenderItem(new InfoItem("A number:", f, env));
-            env.AddRenderItem(new ExpressionItem(new Literal(123.45f), p, f, env));
+            control.AddRenderItem(new InfoItem("A number:", f, env));
+            control.AddRenderItem(
+                new ExpressionItem(new Literal(123.45f), p, f, env));
 
-            env.AddRenderItem(new InfoItem("A variable:", f, env));
-            env.AddRenderItem(new ExpressionItem(new VariableAccess("x"), p, f, env));
+            control.AddRenderItem(new InfoItem("A variable:", f, env));
+            control.AddRenderItem(
+                new ExpressionItem(new VariableAccess("x"), p, f, env));
 
-            env.AddRenderItem(new InfoItem("A function call: ", f, env));
-            env.AddRenderItem(new ExpressionItem(
+            control.AddRenderItem(new InfoItem("A function call: ", f, env));
+            control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     CosineFunction.Value,
                     new VariableAccess("x")), p, f, env));
 
-            env.AddRenderItem(new InfoItem("A simple expression,  \"x + y/2\" :", f, env));
-            env.AddRenderItem(new ExpressionItem(
+            control.AddRenderItem(
+                new InfoItem("A simple expression,  \"x + y/2\" :", f, env));
+            control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AdditionOperation.Value,
                     new VariableAccess("x"),
@@ -55,27 +58,29 @@ namespace MetaphysicsIndustries.Ligra.Commands
                         new VariableAccess("y"),
                         new Literal(2))), p, f, env));
 
-            env.AddRenderItem(new InfoItem("Some derivatives, starting with x^3:", f, env));
+            control.AddRenderItem(
+                new InfoItem("Some derivatives, starting with x^3:", f, env));
             var parser = new SolusParser();
             expr = parser.GetExpression("x^3", env);
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
             DerivativeTransformer derive = new DerivativeTransformer();
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
 
-            env.AddRenderItem(new InfoItem("Some variable assignments: ", f, env));
-            env.AddRenderItem(new ExpressionItem(
+            control.AddRenderItem(
+                new InfoItem("Some variable assignments: ", f, env));
+            control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AssignOperation.Value,
                     new VariableAccess("mu"),
                     new Literal(0.5f)),
                 p,
                 f, env));
-            env.AddRenderItem(new ExpressionItem(
+            control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AssignOperation.Value,
                     new VariableAccess("sigma"),
@@ -125,33 +130,51 @@ namespace MetaphysicsIndustries.Ligra.Commands
                                     new VariableAccess("sigma"),
                                     new Literal(2))))));
 
-            env.AddRenderItem(new InfoItem(
-                "A complex expression, \"(1/(sigma*sqrt(2*pi))) * e ^ ( (x - mu)^2 / (-2 * sigma^2))\"", f, env));
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(
+                new InfoItem(
+                    "A complex expression, \"(1/(sigma*sqrt(2*pi))) * e ^ " +
+                    "( (x - mu)^2 / (-2 * sigma^2))\"", f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
             //(1/(sigma*sqrt(2*pi))) * e ^ ( (x - mu)^2 / (-2 * sigma^2))
 
-            env.AddRenderItem(new InfoItem("A plot of the expression: ", f, env));
-            env.AddRenderItem(new GraphItem(expr, p, "x", parser, env));
+            control.AddRenderItem(
+                new InfoItem("A plot of the expression: ", f, env));
+            control.AddRenderItem(new GraphItem(expr, p, "x", parser, env));
 
-            env.AddRenderItem(new InfoItem("Multiple plots on the same axes, \"x^3\", \"3 * x^2\", \"6 * x\":", f,
-                env));
-            env.AddRenderItem(new GraphItem(
+            control.AddRenderItem(
+                new InfoItem(
+                    "Multiple plots on the same axes, \"x^3\", " +
+                    "\"3 * x^2\", \"6 * x\":",
+                    f, env));
+            control.AddRenderItem(new GraphItem(
                 parser, env,
-                new GraphEntry(parser.GetExpression("x^3", env), LPen.Blue, "x"),
-                new GraphEntry(parser.GetExpression("3*x^2", env), LPen.Green, "x"),
-                new GraphEntry(parser.GetExpression("6*x", env), LPen.Red, "x")));
+                new GraphEntry(parser.GetExpression("x^3", env),
+                    LPen.Blue, "x"),
+                new GraphEntry(parser.GetExpression("3*x^2", env),
+                    LPen.Green, "x"),
+                new GraphEntry(parser.GetExpression("6*x", env),
+                    LPen.Red, "x")));
 
-            env.AddRenderItem(new InfoItem("A plot that changes with time, \"sin(x+t)\":", f, env));
-            env.AddRenderItem(new GraphItem(parser.GetExpression("sin(x+t)", env), p, "x", parser, env));
+            control.AddRenderItem(new InfoItem(
+                "A plot that changes with time, \"sin(x+t)\":", f, env));
+            control.AddRenderItem(
+                new GraphItem(
+                    parser.GetExpression("sin(x+t)", env),
+                    p,
+                    "x", parser, env));
 
-            expr = parser.GetExpression("unitstep((x*x+y*y)^0.5+2*(sin(t)-1))*cos(5*y+2*t)", env);
-            env.AddRenderItem(new InfoItem(
-                "Another complex expression, \"unitstep((x*x+y*y)^0.5+2*(sin(t)-1))*cos(5*y+2*t)\",\r\nwhere t is time:",
+            expr = parser.GetExpression(
+                "unitstep((x*x+y*y)^0.5+2*(sin(t)-1))*cos(5*y+2*t)", env);
+            control.AddRenderItem(new InfoItem(
+                "Another complex expression, \"unitstep((x*x+y*y)^0.5+" +
+                "2*(sin(t)-1))*cos(5*y+2*t)\",\r\nwhere t is time:",
                 f, env));
-            env.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
 
-            env.AddRenderItem(new InfoItem("A 3d plot: ", f, env));
-            env.AddRenderItem(new Graph3dItem(expr, LPen.Black, LBrush.Green, -4, 4, -4, 4, -2, 6, "x", "y", env));
+            control.AddRenderItem(new InfoItem("A 3d plot: ", f, env));
+            control.AddRenderItem(
+                new Graph3dItem(expr, LPen.Black, LBrush.Green, -4, 4, -4, 4,
+                    -2, 6, "x", "y", env));
         }
     }
 }

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -33,22 +33,22 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             Expression expr;
 
-            control.AddRenderItem(new InfoItem("A number:", f, env));
+            control.AddRenderItem(new InfoItem("A number:", f));
             control.AddRenderItem(
-                new ExpressionItem(new Literal(123.45f), p, f, env));
+                new ExpressionItem(new Literal(123.45f), p, f));
 
-            control.AddRenderItem(new InfoItem("A variable:", f, env));
+            control.AddRenderItem(new InfoItem("A variable:", f));
             control.AddRenderItem(
-                new ExpressionItem(new VariableAccess("x"), p, f, env));
+                new ExpressionItem(new VariableAccess("x"), p, f));
 
-            control.AddRenderItem(new InfoItem("A function call: ", f, env));
+            control.AddRenderItem(new InfoItem("A function call: ", f));
             control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     CosineFunction.Value,
-                    new VariableAccess("x")), p, f, env));
+                    new VariableAccess("x")), p, f));
 
             control.AddRenderItem(
-                new InfoItem("A simple expression,  \"x + y/2\" :", f, env));
+                new InfoItem("A simple expression,  \"x + y/2\" :", f));
             control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AdditionOperation.Value,
@@ -56,37 +56,38 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     new FunctionCall(
                         DivisionOperation.Value,
                         new VariableAccess("y"),
-                        new Literal(2))), p, f, env));
+                        new Literal(2))),
+                p, f));
 
             control.AddRenderItem(
-                new InfoItem("Some derivatives, starting with x^3:", f, env));
+                new InfoItem("Some derivatives, starting with x^3:", f));
             var parser = new SolusParser();
             expr = parser.GetExpression("x^3", env);
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
             DerivativeTransformer derive = new DerivativeTransformer();
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
             expr = derive.Transform(expr, new VariableTransformArgs("x"));
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
 
             control.AddRenderItem(
-                new InfoItem("Some variable assignments: ", f, env));
+                new InfoItem("Some variable assignments: ", f));
             control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AssignOperation.Value,
                     new VariableAccess("mu"),
                     new Literal(0.5f)),
                 p,
-                f, env));
+                f));
             control.AddRenderItem(new ExpressionItem(
                 new FunctionCall(
                     AssignOperation.Value,
                     new VariableAccess("sigma"),
                     new Literal(0.2f)),
                 p,
-                f, env));
+                f));
 
             env.Variables["mu"] = new Literal(0.5f);
             env.Variables["sigma"] = new Literal(0.2f);
@@ -133,19 +134,20 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.AddRenderItem(
                 new InfoItem(
                     "A complex expression, \"(1/(sigma*sqrt(2*pi))) * e ^ " +
-                    "( (x - mu)^2 / (-2 * sigma^2))\"", f, env));
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+                    "( (x - mu)^2 / (-2 * sigma^2))\"",
+                    f));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
             //(1/(sigma*sqrt(2*pi))) * e ^ ( (x - mu)^2 / (-2 * sigma^2))
 
             control.AddRenderItem(
-                new InfoItem("A plot of the expression: ", f, env));
+                new InfoItem("A plot of the expression: ", f));
             control.AddRenderItem(new GraphItem(expr, p, "x", parser, env));
 
             control.AddRenderItem(
                 new InfoItem(
                     "Multiple plots on the same axes, \"x^3\", " +
                     "\"3 * x^2\", \"6 * x\":",
-                    f, env));
+                    f));
             control.AddRenderItem(new GraphItem(
                 parser, env,
                 new GraphEntry(parser.GetExpression("x^3", env),
@@ -156,7 +158,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     LPen.Red, "x")));
 
             control.AddRenderItem(new InfoItem(
-                "A plot that changes with time, \"sin(x+t)\":", f, env));
+                "A plot that changes with time, \"sin(x+t)\":", f));
             control.AddRenderItem(
                 new GraphItem(
                     parser.GetExpression("sin(x+t)", env),
@@ -168,10 +170,10 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.AddRenderItem(new InfoItem(
                 "Another complex expression, \"unitstep((x*x+y*y)^0.5+" +
                 "2*(sin(t)-1))*cos(5*y+2*t)\",\r\nwhere t is time:",
-                f, env));
-            control.AddRenderItem(new ExpressionItem(expr, p, f, env));
+                f));
+            control.AddRenderItem(new ExpressionItem(expr, p, f));
 
-            control.AddRenderItem(new InfoItem("A 3d plot: ", f, env));
+            control.AddRenderItem(new InfoItem("A 3d plot: ", f));
             control.AddRenderItem(
                 new Graph3dItem(expr, LPen.Black, LBrush.Green, -4, 4, -4, 4,
                     -2, 6, "x", "y", env));

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -23,7 +23,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            var f = env.Font;
+            var f = control.DrawSettings.Font;
             var p = LPen.Blue;
 
             if (!env.Variables.ContainsKey("x")) env.Variables.Add("x", new Literal(0));

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -16,12 +16,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string DocString =>
             @"example - Show some of the things that Ligra can do";
 
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {

--- a/Commands/ExampleCommand.cs
+++ b/Commands/ExampleCommand.cs
@@ -20,7 +20,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             var f = env.Font;
             var p = LPen.Blue;

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -1,5 +1,6 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -17,13 +18,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         private readonly Expression _expr;
         
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             Execute(input, args, env, control, _expr);
         }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -25,7 +25,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            Execute(input, args, env, _expr);
+            Execute(input, args, env, control, _expr);
         }
 
         public override string GetInputLabel(string input, LigraEnvironment env)
@@ -33,11 +33,13 @@ namespace MetaphysicsIndustries.Ligra.Commands
             return string.Format("$ {0}", _expr);
         }
 
-        public static void Execute(string input, string[] args, LigraEnvironment env, Expression expr)
+        public static void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control, Expression expr)
         {
             expr = expr.PreliminaryEval(env);
 
-            env.AddRenderItem(new ExpressionItem(expr, LPen.Blue, env.Font, env));
+            control.AddRenderItem(
+                new ExpressionItem(expr, LPen.Blue, env.Font, env));
         }
     }
 }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -41,7 +41,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             control.AddRenderItem(
                 new ExpressionItem(
-                    expr, LPen.Blue, control.DrawSettings.Font, env));
+                    expr, LPen.Blue, control.DrawSettings.Font));
         }
     }
 }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -28,7 +28,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             Execute(input, args, env, control, _expr);
         }
 
-        public override string GetInputLabel(string input, LigraEnvironment env)
+        public override string GetInputLabel(string input,
+            LigraEnvironment env, ILigraUI control)
         {
             return string.Format("$ {0}", _expr);
         }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -22,7 +22,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             Execute(input, args, env, _expr);
         }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -39,7 +39,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             expr = expr.PreliminaryEval(env);
 
             control.AddRenderItem(
-                new ExpressionItem(expr, LPen.Blue, env.Font, env));
+                new ExpressionItem(
+                    expr, LPen.Blue, control.DrawSettings.Font, env));
         }
     }
 }

--- a/Commands/ExprCommand.cs
+++ b/Commands/ExprCommand.cs
@@ -1,5 +1,4 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -7,33 +6,20 @@ namespace MetaphysicsIndustries.Ligra.Commands
 {
     public class ExprCommand : Command
     {
-        public static readonly ExprCommand Value = new ExprCommand(null);
+        public static readonly ExprCommand Value = new ExprCommand();
 
         public override string Name => "expr";
-
-        public ExprCommand(Expression expr)
-        {
-            _expr = expr;
-        }
-
-        private readonly Expression _expr;
-        
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            Execute(input, args, env, control, _expr);
+            Execute(input, args, env, control, ((ExprCommandData) data).Expr);
         }
 
         public override string GetInputLabel(string input,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            return string.Format("$ {0}", _expr);
+            return string.Format("$ {0}", ((ExprCommandData) data).Expr);
         }
 
         public static void Execute(string input, string[] args,
@@ -45,5 +31,16 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 new ExpressionItem(
                     expr, LPen.Blue, control.DrawSettings.Font));
         }
+    }
+
+    public class ExprCommandData : ICommandData
+    {
+        public ExprCommandData(Expression expr)
+        {
+            Expr = expr;
+        }
+
+        public Solus.Commands.Command Command => ExprCommand.Value;
+        public Expression Expr { get; }
     }
 }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -47,7 +47,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var expr2 = new FunctionCall(AssignOperation.Value, fcall, func.Expression);
 
             control.AddRenderItem(new ExpressionItem(expr2, LPen.Blue,
-                control.DrawSettings.Font, env));
+                control.DrawSettings.Font));
         }
     }
 }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -14,6 +14,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "func_assign";
 
+        public override bool ModifiesEnvironment => true;
+
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -46,7 +46,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var fcall = new FunctionCall(func, varrefs);
             var expr2 = new FunctionCall(AssignOperation.Value, fcall, func.Expression);
 
-            control.AddRenderItem(new ExpressionItem(expr2, LPen.Blue, env.Font, env));
+            control.AddRenderItem(new ExpressionItem(expr2, LPen.Blue,
+                control.DrawSettings.Font, env));
         }
     }
 }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -28,10 +28,11 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            Execute(input, args, env, _func);
+            Execute(input, args, env, control, _func);
         }
         
-        public void Execute(string input, string[] args, LigraEnvironment env, UserDefinedFunction func)
+        public void Execute(string input, string[] args, LigraEnvironment env,
+            ILigraUI control, UserDefinedFunction func)
         {
 //            var func = new UserDefinedFunction(funcname, argnames, expr);
             if (env.Functions.ContainsKey(func.DisplayName))
@@ -45,7 +46,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             var fcall = new FunctionCall(func, varrefs);
             var expr2 = new FunctionCall(AssignOperation.Value, fcall, func.Expression);
 
-            env.AddRenderItem(new ExpressionItem(expr2, LPen.Blue, env.Font, env));
+            control.AddRenderItem(new ExpressionItem(expr2, LPen.Blue, env.Font, env));
         }
     }
 }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -25,7 +25,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             Execute(input, args, env, _func);
         }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -10,29 +10,17 @@ namespace MetaphysicsIndustries.Ligra.Commands
     public class FuncAssignCommand : Command
     {
         public static readonly FuncAssignCommand Value =
-            new FuncAssignCommand(null);
+            new FuncAssignCommand();
 
         public override string Name => "func_assign";
-
-        public FuncAssignCommand(UserDefinedFunction func)
-        {
-            _func = func;
-        }
-
-        private readonly UserDefinedFunction _func;
-        
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            Execute(input, args, env, data, control, _func);
+            Execute(input, args, env, data, control,
+                ((FuncAssignCommandData)data).Func);
         }
-        
+
         public void Execute(string input, string[] args, LigraEnvironment env,
             ICommandData data, ILigraUI control, UserDefinedFunction func)
         {
@@ -49,5 +37,16 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.AddRenderItem(new ExpressionItem(expr2, LPen.Blue,
                 control.DrawSettings.Font));
         }
+    }
+
+    public class FuncAssignCommandData : ICommandData
+    {
+        public FuncAssignCommandData(UserDefinedFunction func)
+        {
+            Func = func;
+        }
+
+        public Solus.Commands.Command Command => FuncAssignCommand.Value;
+        public UserDefinedFunction Func { get; }
     }
 }

--- a/Commands/FuncAssignCommand.cs
+++ b/Commands/FuncAssignCommand.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 
@@ -20,25 +21,24 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         private readonly UserDefinedFunction _func;
         
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            Execute(input, args, env, control, _func);
+            Execute(input, args, env, data, control, _func);
         }
         
         public void Execute(string input, string[] args, LigraEnvironment env,
-            ILigraUI control, UserDefinedFunction func)
+            ICommandData data, ILigraUI control, UserDefinedFunction func)
         {
 //            var func = new UserDefinedFunction(funcname, argnames, expr);
-            if (env.Functions.ContainsKey(func.DisplayName))
-            {
-                env.Functions.Remove(func.DisplayName);
-            }
+            if (env.ContainsFunction(func.DisplayName))
+                env.RemoveFunction(func.DisplayName);
 
             env.AddFunction(func);
 

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
@@ -38,13 +39,14 @@ List the available topics:
   help list
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             Execute(input, args, env, control, _topic);
         }
@@ -76,17 +78,17 @@ List the available topics:
                 return "This command does not provide any information.";
             }
 
-            if (env.Functions.ContainsKey(topic))
+            if (env.ContainsFunction(topic))
             {
-                if (!string.IsNullOrEmpty(env.Functions[topic].DocString))
-                    return env.Functions[topic].DocString;
+                if (!string.IsNullOrEmpty(env.GetFunction(topic).DocString))
+                    return env.GetFunction(topic).DocString;
                 return "This function does not provide any information.";
             }
 
-            if (env.Macros.ContainsKey(topic))
+            if (env.ContainsMacro(topic))
             {
-                if (!string.IsNullOrEmpty(env.Macros[topic].DocString))
-                    return env.Macros[topic].DocString;
+                if (!string.IsNullOrEmpty(env.GetMacro(topic).DocString))
+                    return env.GetMacro(topic).DocString;
                 return "This macro does not provide any information.";
             }
 
@@ -130,11 +132,11 @@ List the available topics:
                 sb.AppendLine();
             }
 
-            if (env.Functions.Count > 0)
+            if (env.CountFunctions() > 0)
             {
                 sb.AppendLine("Functions:");
                 line = "";
-                var functions = env.Functions.Keys.ToList();
+                var functions = env.GetFunctionNames().ToList();
                 functions.Sort();
                 foreach (var f in functions)
                     AddItem(f);
@@ -143,11 +145,11 @@ List the available topics:
                 sb.AppendLine();
             }
 
-            if (env.Macros.Count > 0)
+            if (env.CountMacros() > 0)
             {
                 sb.AppendLine("Macros:");
                 line = "";
-                var macros = env.Macros.Keys.ToList();
+                var macros = env.GetMacroNames().ToList();
                 macros.Sort();
                 foreach (var m in macros)
                     AddItem(m);
@@ -156,11 +158,11 @@ List the available topics:
                 sb.AppendLine();
             }
 
-            if (env.Variables.Count > 0)
+            if (env.CountVariables() > 0)
             {
                 sb.AppendLine("Variables:");
                 line = "";
-                var variables = env.Variables.Keys.ToList();
+                var variables = env.GetVariableNames().ToList();
                 variables.Sort();
                 foreach (var v in variables)
                     AddItem(v);

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -46,10 +46,11 @@ List the available topics:
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            Execute(input, args, env, _topic);
+            Execute(input, args, env, control, _topic);
         }
 
-        public void Execute(string input, string[] args, LigraEnvironment env, string topic)
+        public void Execute(string input, string[] args, LigraEnvironment env,
+            ILigraUI control, string topic)
         {
             string text;
             
@@ -60,7 +61,7 @@ List the available topics:
             else
                 text = ConstructText(env);
             
-            env.AddRenderItem(new HelpItem(env.Font, env, text));
+            control.AddRenderItem(new HelpItem(env.Font, env, text));
         }
         
         public static string ConstructText(LigraEnvironment env, string topic = "help")

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -3,14 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
     public class HelpCommand : Command
     {
-        public static readonly HelpCommand Value = new HelpCommand(null);
+        public static readonly HelpCommand Value = new HelpCommand();
 
         private static Dictionary<string, string> _helpLookups = 
             new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
@@ -20,13 +19,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
             _helpLookups["ligra"] = @"Ligra - Advanced Mathematics Visualization and Simulation Program";
             _helpLookups["t"] = "default time variable";
         }
-
-        public HelpCommand(string topic)
-        {
-            _topic = topic;
-        }
-
-        private readonly string _topic;
 
         public override string Name => "help";
         public override string DocString =>
@@ -39,16 +31,10 @@ List the available topics:
   help list
 ";
 
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            Execute(input, args, env, control, _topic);
+            Execute(input, args, env, control, ((HelpCommandData) data).Topic);
         }
 
         public void Execute(string input, string[] args, LigraEnvironment env,
@@ -186,5 +172,16 @@ List the available topics:
 
             return sb.ToString();
         }
+    }
+
+    public class HelpCommandData : ICommandData
+    {
+        public HelpCommandData(string topic)
+        {
+            Topic = topic;
+        }
+
+        public Solus.Commands.Command Command => HelpCommand.Value;
+        public string Topic { get; }
     }
 }

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -62,7 +62,7 @@ List the available topics:
                 text = ConstructText(env, control);
             
             control.AddRenderItem(
-                new HelpItem(control.DrawSettings.Font, env, text));
+                new HelpItem(control.DrawSettings.Font, text));
         }
         
         public static string ConstructText(LigraEnvironment env,

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -55,22 +55,24 @@ List the available topics:
             string text;
             
             if (!string.IsNullOrEmpty(topic))
-                text = ConstructText(env, topic);
+                text = ConstructText(env, control, topic);
             else if (args.Length > 1)
-                text = ConstructText(env, args[1]);
+                text = ConstructText(env, control, args[1]);
             else
-                text = ConstructText(env);
+                text = ConstructText(env, control);
             
             control.AddRenderItem(
                 new HelpItem(control.DrawSettings.Font, env, text));
         }
         
-        public static string ConstructText(LigraEnvironment env, string topic = "help")
+        public static string ConstructText(LigraEnvironment env,
+            ILigraUI control, string topic = "help")
         {
-            if (env.Commands.ContainsKey(topic))
+            if (control.Commands.ContainsKey(topic))
             {
-                if (!string.IsNullOrEmpty(env.Commands[topic].DocString))
-                    return env.Commands[topic].DocString;
+                if (!string.IsNullOrEmpty(
+                    control.Commands[topic].DocString))
+                    return control.Commands[topic].DocString;
                 return "This command does not provide any information.";
             }
 
@@ -92,12 +94,13 @@ List the available topics:
                 return _helpLookups[topic];
 
             if (topic == "list")
-                return ConstructListText(env);
+                return ConstructListText(env, control);
 
             return "Unknown topic \"" + topic + "\"";
         }
 
-        public static string ConstructListText(LigraEnvironment env)
+        public static string ConstructListText(LigraEnvironment env,
+            ILigraUI control)
         {
             var sb = new StringBuilder();
             var line = "";
@@ -114,11 +117,11 @@ List the available topics:
                 line += item;
             }
 
-            if (env.Commands.Count > 0)
+            if (control.Commands.Count > 0)
             {
                 sb.AppendLine("Commands:");
                 line = "";
-                var commands = env.Commands.Keys.ToList();
+                var commands = control.Commands.Keys.ToList();
                 commands.Sort();
                 foreach (var c in commands)
                     AddItem(c);

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -61,7 +61,8 @@ List the available topics:
             else
                 text = ConstructText(env);
             
-            control.AddRenderItem(new HelpItem(env.Font, env, text));
+            control.AddRenderItem(
+                new HelpItem(control.DrawSettings.Font, env, text));
         }
         
         public static string ConstructText(LigraEnvironment env, string topic = "help")

--- a/Commands/HelpCommand.cs
+++ b/Commands/HelpCommand.cs
@@ -43,7 +43,8 @@ List the available topics:
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             Execute(input, args, env, _topic);
         }

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -25,11 +25,12 @@ Clear the command history:
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             if (args.Length > 1 && args[1].ToLower() == "clear")
             {
-                ClearHistory(env);
+                ClearHistory(env, control);
             }
             else
             {

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -34,8 +34,9 @@ Clear the command history:
             }
             else
             {
-                string s = string.Join("\r\n", env.History.ToArray());
-                env.AddRenderItem(new InfoItem(s + "\r\n", env.Font, env));
+                var s = string.Join("\r\n", env.History.ToArray());
+                control.AddRenderItem(
+                    new InfoItem(s + "\r\n", env.Font, env));
             }
         }
     }

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -37,7 +37,7 @@ Clear the command history:
             {
                 var s = string.Join("\r\n", control.History.ToArray());
                 control.AddRenderItem(
-                    new InfoItem(s + "\r\n", env.Font, env));
+                    new InfoItem(s + "\r\n", control.DrawSettings.Font, env));
             }
         }
     }

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
 
@@ -34,7 +35,7 @@ Clear the command history:
             }
             else
             {
-                var s = string.Join("\r\n", env.History.ToArray());
+                var s = string.Join("\r\n", control.History.ToArray());
                 control.AddRenderItem(
                     new InfoItem(s + "\r\n", env.Font, env));
             }

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
 {
@@ -21,13 +22,14 @@ Clear the command history:
   (Equivalent to ""clear history"" command)
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             if (args.Length > 1 && args[1].ToLower() == "clear")
             {

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -37,7 +37,7 @@ Clear the command history:
             {
                 var s = string.Join("\r\n", control.History.ToArray());
                 control.AddRenderItem(
-                    new InfoItem(s + "\r\n", control.DrawSettings.Font, env));
+                    new InfoItem(s + "\r\n", control.DrawSettings.Font));
             }
         }
     }

--- a/Commands/HistoryCommand.cs
+++ b/Commands/HistoryCommand.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -21,12 +20,6 @@ Clear the command history:
 
   (Equivalent to ""clear history"" command)
 ";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -26,18 +26,18 @@ namespace MetaphysicsIndustries.Ligra.Commands
             {
                 control.AddRenderItem(
                     new ErrorItem(input, "Too few parameters", font,
-                        brush, env, input.IndexOf(args[0])));
+                        brush, input.IndexOf(args[0])));
             }
             else if (!env.Variables.ContainsKey(args[1]))
             {
                 control.AddRenderItem(new ErrorItem(input, 
-                    "Parameter must be a variable", font, brush, env,
+                    "Parameter must be a variable", font, brush,
                     input.IndexOf(args[1])));
             }
             else if (!System.IO.File.Exists(args[2]))
             {
                 control.AddRenderItem(new ErrorItem(input, 
-                    "Parameter must be a file name", font, brush, env,
+                    "Parameter must be a file name", font, brush,
                     input.IndexOf(args[1])));
             }
             else
@@ -56,8 +56,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     env.Variables[varName] = new Literal(mat);
 
                     control.AddRenderItem(
-                        new InfoItem("Image loaded successfully", font,
-                            env));
+                        new InfoItem("Image loaded successfully", font));
                 }
                 catch (Exception e)
                 {
@@ -67,8 +66,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                             $"There was an error while loading the " +
                             $"file: \r\n{filename}\r\n{e}",
                             font,
-                            brush,
-                            env));
+                            brush));
                 }
             }
         }

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -16,7 +16,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             var font = env.Font;
             var brush = LBrush.Red;

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -11,13 +12,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "example";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             var font = control.DrawSettings.Font;
             var brush = LBrush.Red;
@@ -28,7 +30,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     new ErrorItem(input, "Too few parameters", font,
                         brush, input.IndexOf(args[0])));
             }
-            else if (!env.Variables.ContainsKey(args[1]))
+            else if (!env.ContainsVariable(args[1]))
             {
                 control.AddRenderItem(new ErrorItem(input, 
                     "Parameter must be a variable", font, brush,
@@ -48,12 +50,10 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 {
                     var mat = SolusEngine.LoadImage(filename);
 
-                    if (!env.Variables.ContainsKey(varName))
-                    {
-                        env.Variables.Add(varName, new Literal(0));
-                    }
+                    if (!env.ContainsVariable(varName))
+                        env.SetVariable(varName, new Literal(0));
 
-                    env.Variables[varName] = new Literal(mat);
+                    env.SetVariable(varName, new Literal(mat));
 
                     control.AddRenderItem(
                         new InfoItem("Image loaded successfully", font));

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -19,7 +19,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            var font = env.Font;
+            var font = control.DrawSettings.Font;
             var brush = LBrush.Red;
 
             if (args.Length < 3)

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -24,16 +24,20 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             if (args.Length < 3)
             {
-                env.AddRenderItem(new ErrorItem(input, "Too few parameters", font, brush, env, input.IndexOf(args[0])));
+                control.AddRenderItem(
+                    new ErrorItem(input, "Too few parameters", font,
+                        brush, env, input.IndexOf(args[0])));
             }
             else if (!env.Variables.ContainsKey(args[1]))
             {
-                env.AddRenderItem(new ErrorItem(input, "Parameter must be a variable", font, brush, env,
+                control.AddRenderItem(new ErrorItem(input, 
+                    "Parameter must be a variable", font, brush, env,
                     input.IndexOf(args[1])));
             }
             else if (!System.IO.File.Exists(args[2]))
             {
-                env.AddRenderItem(new ErrorItem(input, "Parameter must be a file name", font, brush, env,
+                control.AddRenderItem(new ErrorItem(input, 
+                    "Parameter must be a file name", font, brush, env,
                     input.IndexOf(args[1])));
             }
             else
@@ -51,13 +55,20 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
                     env.Variables[varName] = new Literal(mat);
 
-                    env.AddRenderItem(new InfoItem("Image loaded successfully", font, env));
+                    control.AddRenderItem(
+                        new InfoItem("Image loaded successfully", font,
+                            env));
                 }
                 catch (Exception e)
                 {
-                    env.AddRenderItem(new ErrorItem(input,
-                        "There was an error while loading the file: \r\n" + filename + "\r\n" + e.ToString(), font,
-                        brush, env));
+                    control.AddRenderItem(
+                        new ErrorItem(
+                            input,
+                            $"There was an error while loading the " +
+                            $"file: \r\n{filename}\r\n{e}",
+                            font,
+                            brush,
+                            env));
                 }
             }
         }

--- a/Commands/LoadImageCommand.cs
+++ b/Commands/LoadImageCommand.cs
@@ -12,12 +12,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "example";
 
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {

--- a/Commands/PaintCommand.cs
+++ b/Commands/PaintCommand.cs
@@ -55,7 +55,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             LigraEnvironment env, ILigraUI control)
         {
             // holy smokes, this is *hideous*
-            var cmd = env.Parser.GetPaintCommand(input, env);
+            var cmd = control.Parser.GetPaintCommand(input, env);
             Execute(input, args, env, control, cmd._expr, cmd._interval1,
                 cmd._interval2);
         }

--- a/Commands/PaintCommand.cs
+++ b/Commands/PaintCommand.cs
@@ -1,5 +1,4 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -22,6 +21,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         private readonly VarInterval _interval2;
 
         public override string Name => "paint";
+
         public override string DocString =>
 @"Mathpaint - Color the pixels of an image using an expression.
 
@@ -47,19 +47,13 @@ namespace MetaphysicsIndustries.Ligra.Commands
   example:
     paint i | j for i=[0..255], j=[0..255]
 ";
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            // holy smokes, this is *hideous*
-            var cmd = control.Parser.GetPaintCommand(input, env);
-            Execute(input, args, env, control, cmd._expr, cmd._interval1,
-                cmd._interval2);
+            var data2 = (PaintCommandData) data;
+            Execute(input, args, env, control, data2.Expr, data2.Interval1,
+                data2.Interval2);
         }
 
         public void Execute(string input, string[] args, LigraEnvironment env,
@@ -72,5 +66,21 @@ namespace MetaphysicsIndustries.Ligra.Commands
                     interval1,
                     interval2, env));
         }
+    }
+
+    public class PaintCommandData : ICommandData
+    {
+        public PaintCommandData(Expression expr, VarInterval interval1,
+            VarInterval interval2)
+        {
+            Expr = expr;
+            Interval1 = interval1;
+            Interval2 = interval2;
+        }
+
+        public Solus.Commands.Command Command => PaintCommand.Value;
+        public Expression Expr { get; }
+        public VarInterval Interval1 { get; }
+        public VarInterval Interval2 { get; }
     }
 }

--- a/Commands/PaintCommand.cs
+++ b/Commands/PaintCommand.cs
@@ -56,12 +56,15 @@ namespace MetaphysicsIndustries.Ligra.Commands
         {
             // holy smokes, this is *hideous*
             var cmd = env.Parser.GetPaintCommand(input, env);
-            Execute(input, args, env, cmd._expr, cmd._interval1, cmd._interval2);
+            Execute(input, args, env, control, cmd._expr, cmd._interval1,
+                cmd._interval2);
         }
 
-        public void Execute(string input, string[] args, LigraEnvironment env, Expression expr, VarInterval interval1, VarInterval interval2)
+        public void Execute(string input, string[] args, LigraEnvironment env,
+            ILigraUI control, Expression expr, VarInterval interval1,
+            VarInterval interval2)
         {
-            env.AddRenderItem(
+            control.AddRenderItem(
                 new MathPaintItem(
                     expr,
                     interval1,

--- a/Commands/PaintCommand.cs
+++ b/Commands/PaintCommand.cs
@@ -1,5 +1,6 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -46,13 +47,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
   example:
     paint i | j for i=[0..255], j=[0..255]
 ";
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             // holy smokes, this is *hideous*
             var cmd = control.Parser.GetPaintCommand(input, env);

--- a/Commands/PaintCommand.cs
+++ b/Commands/PaintCommand.cs
@@ -51,7 +51,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             // holy smokes, this is *hideous*
             var cmd = env.Parser.GetPaintCommand(input, env);

--- a/Commands/PlotCommand.cs
+++ b/Commands/PlotCommand.cs
@@ -82,7 +82,8 @@ Plot one or more expressions that vary over two variable as a 3D graph:
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             // TODO: don't create another instance of the class within the class.
             var cmd = env.Parser.GetPlotCommand(input, env);

--- a/Commands/PlotCommand.cs
+++ b/Commands/PlotCommand.cs
@@ -24,10 +24,11 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "plot";
 
-        public override string GetInputLabel(string input, LigraEnvironment env)
+        public override string GetInputLabel(string input,
+            LigraEnvironment env, ILigraUI control)
         {
             // TODO: don't create another instance of the class within the class.
-            var cmd = env.Parser.GetPlotCommand(input, env);
+            var cmd = control.Parser.GetPlotCommand(input, env);
             var label = string.Format("$ plot {0} for {1}",
                 string.Join(", ", cmd._exprs.Select(Expression.ToString)),
                 string.Join(", ", cmd._intervals.Select((VarInterval vi) => vi.ToString())));
@@ -86,7 +87,7 @@ Plot one or more expressions that vary over two variable as a 3D graph:
             LigraEnvironment env, ILigraUI control)
         {
             // TODO: don't create another instance of the class within the class.
-            var cmd = env.Parser.GetPlotCommand(input, env);
+            var cmd = control.Parser.GetPlotCommand(input, env);
             Execute(input, args, env, control, cmd._exprs, cmd._intervals);
         }
 

--- a/Commands/PlotCommand.cs
+++ b/Commands/PlotCommand.cs
@@ -26,13 +26,13 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string Name => "plot";
 
         public override string GetInputLabel(string input,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            // TODO: don't create another instance of the class within the class.
-            var cmd = control.Parser.GetPlotCommand(input, env);
+            var data2 = (PlotCommandData) data;
             var label = string.Format("$ plot {0} for {1}",
-                string.Join(", ", cmd._exprs.Select(Expression.ToString)),
-                string.Join(", ", cmd._intervals.Select((VarInterval vi) => vi.ToString())));
+                string.Join(", ", data2.Exprs.Select(Expression.ToString)),
+                string.Join(", ",
+                    data2.Intervals.Select(vi => vi.ToString())));
             return label;
         }
 
@@ -79,18 +79,11 @@ Plot one or more expressions that vary over two variable as a 3D graph:
     plot sin(x) + cos(y) for -5 < x < 5, -5 < y < 5
 ";
 
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            // TODO: don't create another instance of the class within the class.
-            var cmd = control.Parser.GetPlotCommand(input, env);
-            Execute(input, args, env, control, cmd._exprs, cmd._intervals);
+            var data2 = (PlotCommandData) data;
+            Execute(input, args, env, control, data2.Exprs, data2.Intervals);
         }
 
         public static void Execute(string input, string[] args,
@@ -184,5 +177,18 @@ Plot one or more expressions that vary over two variable as a 3D graph:
                     intervals[1].Variable, env));
             }
         }
+    }
+
+    public class PlotCommandData : ICommandData
+    {
+        public PlotCommandData(Expression[] exprs, VarInterval[] intervals)
+        {
+            Exprs = exprs;
+            Intervals = intervals;
+        }
+
+        public Solus.Commands.Command Command => PlotCommand.Value;
+        public Expression[] Exprs { get; }
+        public VarInterval[] Intervals { get; }
     }
 }

--- a/Commands/PlotCommand.cs
+++ b/Commands/PlotCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Values;
 
@@ -78,13 +79,14 @@ Plot one or more expressions that vary over two variable as a 3D graph:
     plot sin(x) + cos(y) for -5 < x < 5, -5 < y < 5
 ";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             // TODO: don't create another instance of the class within the class.
             var cmd = control.Parser.GetPlotCommand(input, env);
@@ -106,7 +108,7 @@ Plot one or more expressions that vary over two variable as a 3D graph:
             {
                 float midpoint = (interval.Interval.LowerBound + interval.Interval.UpperBound) / 2;
                 var literal = new Literal(midpoint);
-                env.Variables[interval.Variable] = literal;
+                env.SetVariable(interval.Variable, literal);
                 literals.Add(literal);
             }
 

--- a/Commands/PlotCommand.cs
+++ b/Commands/PlotCommand.cs
@@ -87,10 +87,12 @@ Plot one or more expressions that vary over two variable as a 3D graph:
         {
             // TODO: don't create another instance of the class within the class.
             var cmd = env.Parser.GetPlotCommand(input, env);
-            Execute(input, args, env, cmd._exprs, cmd._intervals);
+            Execute(input, args, env, control, cmd._exprs, cmd._intervals);
         }
 
-        public static void Execute(string input, string[] args, LigraEnvironment env, Expression[] exprs, VarInterval[] intervals)
+        public static void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control, Expression[] exprs,
+            VarInterval[] intervals)
         {
             if (env == null) throw new ArgumentNullException("env");
             if (exprs == null || exprs.Length < 1) throw new ArgumentNullException("exprs");
@@ -137,7 +139,8 @@ Plot one or more expressions that vary over two variable as a 3D graph:
                     i++;
                 }
 
-                env.AddRenderItem(new GraphItem(new SolusParser(), env, entries.ToArray()));
+                control.AddRenderItem(
+                    new GraphItem(new SolusParser(), env, entries.ToArray()));
             }
             else // intervals.Length == 2
             {
@@ -168,7 +171,7 @@ Plot one or more expressions that vary over two variable as a 3D graph:
                 float zmin = zs.Min();
                 float zmax = zs.Max();
 
-                env.AddRenderItem(new Graph3dItem(expr, LPen.Black, LBrush.Green,
+                control.AddRenderItem(new Graph3dItem(expr, LPen.Black, LBrush.Green,
                     intervals[0].Interval.LowerBound,
                     intervals[0].Interval.UpperBound,
                     intervals[1].Interval.LowerBound,

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -130,7 +130,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             m[4, 2] = one;
             m[4, 3] = negOne;
 
-            env.AddRenderItem(new ExpressionItem(m, LPen.Blue, env.Font, env));
+            control.AddRenderItem(
+                new ExpressionItem(m, LPen.Blue, env.Font, env));
             env.ClearCanvas();
         }
 

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -132,7 +132,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             control.AddRenderItem(
                 new ExpressionItem(
-                    m, LPen.Blue, control.DrawSettings.Font, env));
+                    m, LPen.Blue, control.DrawSettings.Font));
             control.ClearCanvas();
         }
 

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -133,7 +133,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             control.AddRenderItem(
                 new ExpressionItem(
                     m, LPen.Blue, control.DrawSettings.Font, env));
-            env.ClearCanvas();
+            control.ClearCanvas();
         }
 
         private static void AddMultRow(SolusEngine engine, MatrixExpression m,

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -13,12 +13,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "tsolve";
 
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -131,7 +131,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             m[4, 3] = negOne;
 
             control.AddRenderItem(
-                new ExpressionItem(m, LPen.Blue, env.Font, env));
+                new ExpressionItem(
+                    m, LPen.Blue, control.DrawSettings.Font, env));
             env.ClearCanvas();
         }
 

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -17,7 +17,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             SolusEngine _engine = new SolusEngine();
             var m = new MatrixExpression(7, 7);

--- a/Commands/TSolveCommand.cs
+++ b/Commands/TSolveCommand.cs
@@ -1,5 +1,6 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Transformers;
@@ -12,39 +13,26 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "tsolve";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             SolusEngine _engine = new SolusEngine();
             var m = new MatrixExpression(7, 7);
 
-            string k;
-            string r;
-            string cs;
+            if (!env.ContainsVariable("k"))
+                env.SetVariable("k", new Literal(0));
 
-            if (!env.Variables.ContainsKey("k"))
-            {
-                env.Variables.Add("k", new Literal(0));
-            }
+            if (!env.ContainsVariable("R"))
+                env.SetVariable("R", new Literal(0));
 
-            if (!env.Variables.ContainsKey("R"))
-            {
-                env.Variables.Add("R", new Literal(0));
-            }
-
-            if (!env.Variables.ContainsKey("Cs"))
-            {
-                env.Variables.Add("Cs", new Literal(0));
-            }
-
-            k = "k";
-            r = "R";
-            cs = "Cs";
+            if (!env.ContainsVariable("Cs"))
+                env.SetVariable("Cs", new Literal(0));
 
             int i;
             int j;

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -10,6 +10,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public static readonly VarAssignCommand Value = new VarAssignCommand();
 
         public override string Name => "var_assign";
+        public override bool ModifiesEnvironment => true;
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -1,5 +1,6 @@
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -20,13 +21,14 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
         public override string Name => "var_assign";
         
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             Execute(input, args, env, control, _varname, _expr);
         }
@@ -34,7 +36,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public void Execute(string input, string[] args, LigraEnvironment env,
             ILigraUI control, string varname, Expression expr)
         {
-            env.Variables[varname] = expr;
+            env.SetVariable(varname, expr);
 
             var expr2 = new FunctionCall(
                 AssignOperation.Value,

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -42,7 +42,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 expr);
 
             control.AddRenderItem(
-                new ExpressionItem(expr2, LPen.Blue, env.Font, env));
+                new ExpressionItem(
+                    expr2, LPen.Blue, control.DrawSettings.Font, env));
         }
     }
 }

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -28,10 +28,11 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ILigraUI control)
         {
-            Execute(input, args, env, _varname, _expr);
+            Execute(input, args, env, control, _varname, _expr);
         }
         
-        public void Execute(string input, string[] args, LigraEnvironment env, string varname, Expression expr)
+        public void Execute(string input, string[] args, LigraEnvironment env,
+            ILigraUI control, string varname, Expression expr)
         {
             env.Variables[varname] = expr;
 
@@ -40,7 +41,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 new VariableAccess(varname),
                 expr);
 
-            env.AddRenderItem(new ExpressionItem(expr2, LPen.Blue, env.Font, env));
+            control.AddRenderItem(
+                new ExpressionItem(expr2, LPen.Blue, env.Font, env));
         }
     }
 }

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -25,7 +25,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             Execute(input, args, env, _varname, _expr);
         }

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -7,32 +7,17 @@ namespace MetaphysicsIndustries.Ligra.Commands
 {
     public class VarAssignCommand : Command
     {
-        public static readonly VarAssignCommand Value =
-            new VarAssignCommand(null, null);
-
-        public VarAssignCommand(string varname, Expression expr)
-        {
-            _varname = varname;
-            _expr = expr;
-        }
-
-        private readonly string _varname;
-        private readonly Expression _expr;
+        public static readonly VarAssignCommand Value = new VarAssignCommand();
 
         public override string Name => "var_assign";
-        
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)
         {
-            Execute(input, args, env, control, _varname, _expr);
+            var data2 = (VarAssignCommandData) data;
+            Execute(input, args, env, control, data2.VarName, data2.Expr);
         }
-        
+
         public void Execute(string input, string[] args, LigraEnvironment env,
             ILigraUI control, string varname, Expression expr)
         {
@@ -47,5 +32,18 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 new ExpressionItem(
                     expr2, LPen.Blue, control.DrawSettings.Font));
         }
+    }
+
+    public class VarAssignCommandData : ICommandData
+    {
+        public VarAssignCommandData(string varname, Expression expr)
+        {
+            VarName = varname;
+            Expr = expr;
+        }
+
+        public Solus.Commands.Command Command => VarAssignCommand.Value;
+        public string VarName { get; }
+        public Expression Expr { get; }
     }
 }

--- a/Commands/VarAssignCommand.cs
+++ b/Commands/VarAssignCommand.cs
@@ -43,7 +43,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
 
             control.AddRenderItem(
                 new ExpressionItem(
-                    expr2, LPen.Blue, control.DrawSettings.Font, env));
+                    expr2, LPen.Blue, control.DrawSettings.Font));
         }
     }
 }

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -40,7 +40,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             }
 
             control.AddRenderItem(
-                new InfoItem(s, control.DrawSettings.Font, env));
+                new InfoItem(s, control.DrawSettings.Font));
         }
     }
 }

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
 namespace MetaphysicsIndustries.Ligra.Commands
@@ -13,18 +14,19 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string DocString =>
             @"vars - Print a list of all defined variables";
 
-        public override void Execute(string input, SolusEnvironment env)
+        public override void Execute(string input, SolusEnvironment env,
+            ICommandData data)
         {
             throw new System.NotImplementedException();
         }
 
         public override void Execute(string input, string[] args,
-            LigraEnvironment env, ILigraUI control)
+            LigraEnvironment env, ICommandData data, ILigraUI control)
         {
             string s = string.Empty;
-            foreach (string var in env.Variables.Keys.ToArray())
+            foreach (string var in env.GetVariableNames().ToArray())
             {
-                Expression value = env.Variables[var];
+                Expression value = env.GetVariable(var);
                 string valueString = value.ToString();
 
                 if (value is VectorExpression ve)

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Expressions;
@@ -21,7 +22,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
             LigraEnvironment env, ILigraUI control)
         {
             string s = string.Empty;
-            foreach (string var in env.Variables.Keys)
+            foreach (string var in env.Variables.Keys.ToArray())
             {
                 Expression value = env.Variables[var];
                 string valueString = value.ToString();
@@ -38,7 +39,7 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 s += var + " = " + valueString + "\r\n";
             }
 
-            env.AddRenderItem(new InfoItem(s, env.Font, env));
+            control.AddRenderItem(new InfoItem(s, env.Font, env));
         }
     }
 }

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -39,7 +39,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
                 s += var + " = " + valueString + "\r\n";
             }
 
-            control.AddRenderItem(new InfoItem(s, env.Font, env));
+            control.AddRenderItem(
+                new InfoItem(s, control.DrawSettings.Font, env));
         }
     }
 }

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -17,7 +17,8 @@ namespace MetaphysicsIndustries.Ligra.Commands
             throw new System.NotImplementedException();
         }
 
-        public override void Execute(string input, string[] args, LigraEnvironment env)
+        public override void Execute(string input, string[] args,
+            LigraEnvironment env, ILigraUI control)
         {
             string s = string.Empty;
             foreach (string var in env.Variables.Keys)

--- a/Commands/VarsCommand.cs
+++ b/Commands/VarsCommand.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
 
@@ -13,12 +12,6 @@ namespace MetaphysicsIndustries.Ligra.Commands
         public override string Name => "vars";
         public override string DocString =>
             @"vars - Print a list of all defined variables";
-
-        public override void Execute(string input, SolusEnvironment env,
-            ICommandData data)
-        {
-            throw new System.NotImplementedException();
-        }
 
         public override void Execute(string input, string[] args,
             LigraEnvironment env, ICommandData data, ILigraUI control)

--- a/DrawSettings.cs
+++ b/DrawSettings.cs
@@ -1,0 +1,9 @@
+namespace MetaphysicsIndustries.Ligra
+{
+    public class DrawSettings
+    {
+        public LFont Font { get; set; } =
+            new LFont(LFont.Families.CourierNew, 12,
+                LFont.Styles.Regular);
+    }
+}

--- a/Expressions/TimeExpression.cs
+++ b/Expressions/TimeExpression.cs
@@ -1,0 +1,30 @@
+using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Expressions;
+using MetaphysicsIndustries.Solus.Values;
+
+namespace MetaphysicsIndustries.Ligra.Expressions
+{
+    public class TimeExpression : Expression
+    {
+        public override IMathObject Eval(SolusEnvironment env)
+        {
+            return CurrentTime.ToNumber();
+        }
+
+        private float CurrentTime => System.Environment.TickCount / 1000.0f;
+
+        public override string ToString()
+        {
+            return CurrentTime.ToString();
+        }
+
+        public override Expression Clone()
+        {
+            return new TimeExpression();
+        }
+
+        public override void AcceptVisitor(IExpressionVisitor visitor)
+        {
+        }
+    }
+}

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -12,5 +12,8 @@ namespace MetaphysicsIndustries.Ligra
         Vector2 ClientSize { get; }
 
         void OpenPlotProperties(GraphItem item);
+
+        IList<string> History { get; }
+        int CurrentHistoryIndex { get; set; }
     }
 }

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -19,5 +19,7 @@ namespace MetaphysicsIndustries.Ligra
         DrawSettings DrawSettings { get; }
 
         void ClearCanvas();
+
+        LigraParser Parser { get; }
     }
 }

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -24,5 +24,7 @@ namespace MetaphysicsIndustries.Ligra
         LigraParser Parser { get; }
 
         Dictionary<string, Command> Commands { get; }
+
+        LigraEnvironment Env { get; }
     }
 }

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using MetaphysicsIndustries.Ligra.Commands;
 using MetaphysicsIndustries.Ligra.RenderItems;
 
 namespace MetaphysicsIndustries.Ligra
@@ -21,5 +22,7 @@ namespace MetaphysicsIndustries.Ligra
         void ClearCanvas();
 
         LigraParser Parser { get; }
+
+        Dictionary<string, Command> Commands { get; }
     }
 }

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -15,5 +15,7 @@ namespace MetaphysicsIndustries.Ligra
 
         IList<string> History { get; }
         int CurrentHistoryIndex { get; set; }
+
+        DrawSettings DrawSettings { get; }
     }
 }

--- a/ILigraUI.cs
+++ b/ILigraUI.cs
@@ -17,5 +17,7 @@ namespace MetaphysicsIndustries.Ligra
         int CurrentHistoryIndex { get; set; }
 
         DrawSettings DrawSettings { get; }
+
+        void ClearCanvas();
     }
 }

--- a/Ligra.csproj
+++ b/Ligra.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Commands\VarAssignCommand.cs" />
     <Compile Include="Commands\VarsCommand.cs" />
     <Compile Include="DrawSettings.cs" />
+    <Compile Include="Expressions\TimeExpression.cs" />
     <Compile Include="GtkRenderer.cs" />
     <Compile Include="LigraControl.cs">
       <SubType>UserControl</SubType>

--- a/Ligra.csproj
+++ b/Ligra.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Commands\TSolveCommand.cs" />
     <Compile Include="Commands\VarAssignCommand.cs" />
     <Compile Include="Commands\VarsCommand.cs" />
+    <Compile Include="DrawSettings.cs" />
     <Compile Include="GtkRenderer.cs" />
     <Compile Include="LigraControl.cs">
       <SubType>UserControl</SubType>

--- a/Ligra.csproj
+++ b/Ligra.csproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MetaphysicsIndustries.Solus, Version=0.4.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>packages\MetaphysicsIndustries.Solus.0.4.0\lib\net40\MetaphysicsIndustries.Solus.dll</HintPath>
+      <HintPath>packages\MetaphysicsIndustries.Solus.0.5.0\lib\net40\MetaphysicsIndustries.Solus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -16,6 +16,7 @@ using System.Drawing;
 using System.Data;
 using System.Text;
 using System.Windows.Forms;
+using MetaphysicsIndustries.Ligra.Commands;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus;
 
@@ -26,6 +27,7 @@ namespace MetaphysicsIndustries.Ligra
         public LigraControl()
         {
             InitializeComponent();
+            Ligra.Commands.Command.InitializeCommands(Commands);
         }
 
         static readonly SolusEngine _engine = new SolusEngine();
@@ -141,5 +143,9 @@ namespace MetaphysicsIndustries.Ligra
         public void ClearCanvas() => Invalidate();
 
         public LigraParser Parser { get; } = new LigraParser();
+
+        public Dictionary<string, Command> Commands { get; } =
+            new Dictionary<string, Command>(
+                StringComparer.InvariantCultureIgnoreCase);
     }
 }

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -137,5 +137,7 @@ namespace MetaphysicsIndustries.Ligra
         public int CurrentHistoryIndex { get; set; } = -1;
 
         public DrawSettings DrawSettings { get; } = new DrawSettings();
+
+        public void ClearCanvas() => Invalidate();
     }
 }

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -139,5 +139,7 @@ namespace MetaphysicsIndustries.Ligra
         public DrawSettings DrawSettings { get; } = new DrawSettings();
 
         public void ClearCanvas() => Invalidate();
+
+        public LigraParser Parser { get; } = new LigraParser();
     }
 }

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -135,5 +135,7 @@ namespace MetaphysicsIndustries.Ligra
 
         public IList<string> History { get; } = new List<string>();
         public int CurrentHistoryIndex { get; set; } = -1;
+
+        public DrawSettings DrawSettings { get; } = new DrawSettings();
     }
 }

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -132,5 +132,8 @@ namespace MetaphysicsIndustries.Ligra
                 item._minY = form.PlotMinY;
             }
         }
+
+        public IList<string> History { get; } = new List<string>();
+        public int CurrentHistoryIndex { get; set; } = -1;
     }
 }

--- a/LigraControl.cs
+++ b/LigraControl.cs
@@ -135,6 +135,8 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
+        public LigraEnvironment Env { get; } = new LigraEnvironment();
+
         public IList<string> History { get; } = new List<string>();
         public int CurrentHistoryIndex { get; set; } = -1;
 

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -4,6 +4,16 @@ namespace MetaphysicsIndustries.Ligra
 {
     public class LigraEnvironment : SolusEnvironment
     {
+        public LigraEnvironment(bool useDefaults = true,
+            SolusEnvironment parent = null)
+            : base(useDefaults, parent)
+        {
+        }
+
+        protected override SolusEnvironment Instantiate(
+            bool useDefaults = false, SolusEnvironment parent = null)
+        {
+            return new LigraEnvironment(useDefaults, parent);
+        }
     }
 }
-

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -1,7 +1,4 @@
-using System;
 using MetaphysicsIndustries.Solus;
-using System.Collections.Generic;
-using MetaphysicsIndustries.Ligra.Commands;
 
 namespace MetaphysicsIndustries.Ligra
 {

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -26,7 +26,6 @@ namespace MetaphysicsIndustries.Ligra
 
         private readonly ILigraUI _control;
 
-        public IList<RenderItem> RenderItems => _control.RenderItems;
         public void AddRenderItem(RenderItem item)
         {
             _control.AddRenderItem(item);

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -20,8 +20,6 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
-        public Action ClearCanvas;
-
         public readonly LigraParser Parser = new LigraParser();
     }
 }

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -1,9 +1,7 @@
 using System;
 using MetaphysicsIndustries.Solus;
 using System.Collections.Generic;
-using System.Drawing;
 using MetaphysicsIndustries.Ligra.Commands;
-using MetaphysicsIndustries.Ligra.RenderItems;
 
 namespace MetaphysicsIndustries.Ligra
 {
@@ -13,8 +11,6 @@ namespace MetaphysicsIndustries.Ligra
         {
             if (control == null) throw new ArgumentNullException("control");
 
-            _control = control;
-
             this.Commands.Clear();
             if (commands == null) return;
             foreach (var kvp in commands)
@@ -22,13 +18,6 @@ namespace MetaphysicsIndustries.Ligra
                 var command = kvp.Value;
                 AddCommand(command);
             }
-        }
-
-        private readonly ILigraUI _control;
-
-        public void AddRenderItem(RenderItem item)
-        {
-            _control.AddRenderItem(item);
         }
 
         public readonly List<string> History = new List<string>();

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -7,9 +7,6 @@ namespace MetaphysicsIndustries.Ligra
 {
     public class LigraEnvironment : SolusEnvironment
     {
-        public LigraEnvironment(ILigraUI control, Dictionary<string, Command> commands)
-        {
-        }
     }
 }
 

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -20,9 +20,6 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
-        public readonly List<string> History = new List<string>();
-        public int CurrentHistoryIndex = -1;
-
         public LFont Font;
         public Action ClearCanvas;
 

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -19,8 +19,6 @@ namespace MetaphysicsIndustries.Ligra
                 AddCommand(command);
             }
         }
-
-        public readonly LigraParser Parser = new LigraParser();
     }
 }
 

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -9,15 +9,6 @@ namespace MetaphysicsIndustries.Ligra
     {
         public LigraEnvironment(ILigraUI control, Dictionary<string, Command> commands)
         {
-            if (control == null) throw new ArgumentNullException("control");
-
-            this.Commands.Clear();
-            if (commands == null) return;
-            foreach (var kvp in commands)
-            {
-                var command = kvp.Value;
-                AddCommand(command);
-            }
         }
     }
 }

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -20,7 +20,6 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
-        public LFont Font;
         public Action ClearCanvas;
 
         public readonly LigraParser Parser = new LigraParser();

--- a/LigraEnvironment.cs
+++ b/LigraEnvironment.cs
@@ -13,7 +13,7 @@ namespace MetaphysicsIndustries.Ligra
         {
             if (control == null) throw new ArgumentNullException("control");
 
-            Control = control;
+            _control = control;
 
             this.Commands.Clear();
             if (commands == null) return;
@@ -24,12 +24,12 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
-        public readonly ILigraUI Control;
+        private readonly ILigraUI _control;
 
-        public IList<RenderItem> RenderItems => Control.RenderItems;
+        public IList<RenderItem> RenderItems => _control.RenderItems;
         public void AddRenderItem(RenderItem item)
         {
-            Control.AddRenderItem(item);
+            _control.AddRenderItem(item);
         }
 
         public readonly List<string> History = new List<string>();

--- a/LigraForm.Commands.cs
+++ b/LigraForm.Commands.cs
@@ -15,13 +15,6 @@ namespace MetaphysicsIndustries.Ligra
 {
     public partial class LigraForm : Form
     {
-        Dictionary<string, Command> _commands = new Dictionary<string, Command>(StringComparer.InvariantCultureIgnoreCase);
-
-        private void InitializeCommands()
-        {
-            Commands.Command.InitializeCommands(_commands);
-        }
-
         private void CdCommand(string input, string[] args, ILigraUI control)
         {
             new CdCommand().Execute(input, args, _env, control);
@@ -29,7 +22,7 @@ namespace MetaphysicsIndustries.Ligra
 
         private void ProcessInput(string input, ILigraUI control)
         {
-            LigraWindow.ProcessInput(input, _env, _commands,
+            LigraWindow.ProcessInput(input, _env, control.Commands,
                 evalTextBox.SelectAll, control);
         }
     }

--- a/LigraForm.Commands.cs
+++ b/LigraForm.Commands.cs
@@ -17,12 +17,12 @@ namespace MetaphysicsIndustries.Ligra
     {
         private void CdCommand(string input, string[] args, ILigraUI control)
         {
-            new CdCommand().Execute(input, args, _env, control);
+            new CdCommand().Execute(input, args, control.Env, control);
         }
 
         private void ProcessInput(string input, ILigraUI control)
         {
-            LigraWindow.ProcessInput(input, _env, control.Commands,
+            LigraWindow.ProcessInput(input, control.Env, control.Commands,
                 evalTextBox.SelectAll, control);
         }
     }

--- a/LigraForm.Commands.cs
+++ b/LigraForm.Commands.cs
@@ -17,7 +17,7 @@ namespace MetaphysicsIndustries.Ligra
     {
         private void CdCommand(string input, string[] args, ILigraUI control)
         {
-            new CdCommand().Execute(input, args, control.Env, control);
+            new CdCommand().Execute(input, args, control.Env, null, control);
         }
 
         private void ProcessInput(string input, ILigraUI control)

--- a/LigraForm.Commands.cs
+++ b/LigraForm.Commands.cs
@@ -22,14 +22,15 @@ namespace MetaphysicsIndustries.Ligra
             Commands.Command.InitializeCommands(_commands);
         }
 
-        private void CdCommand(string input, string[] args)
+        private void CdCommand(string input, string[] args, ILigraUI control)
         {
-            new CdCommand().Execute(input, args, _env);
+            new CdCommand().Execute(input, args, _env, control);
         }
 
-        private void ProcessInput(string input)
+        private void ProcessInput(string input, ILigraUI control)
         {
-            LigraWindow.ProcessInput(input, _env, _commands, evalTextBox.SelectAll);
+            LigraWindow.ProcessInput(input, _env, _commands,
+                evalTextBox.SelectAll, control);
         }
     }
 }

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -145,7 +145,7 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItem_Click(object sender, EventArgs e)
         {
-            Commands.Command.ClearOutput(ligraControl1.Env, ligraControl1);
+            Commands.Command.ClearOutput(ligraControl1);
         }
 
         private void timer1_Tick(object sender, EventArgs e)

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -197,13 +197,13 @@ namespace MetaphysicsIndustries.Ligra
                     var font = LFont.FromSwf(ligraControl1.Font);
                     if (ee is Solus.Exceptions.ParseException ee2)
                     {
-                        _env.AddRenderItem(
+                        ligraControl1.AddRenderItem(
                             new ErrorItem(input, ee2.Error, font, LBrush.Red,
                                 _env, ee2.Location));
                     }
                     else
                     {
-                        _env.AddRenderItem(
+                        ligraControl1.AddRenderItem(
                             new ErrorItem(input,
                                 "There was an error: " + ee.ToString(), font,
                                 LBrush.Red, _env));

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -25,13 +25,9 @@ namespace MetaphysicsIndustries.Ligra
                 this.Controls.Remove(this.toolStripContainer1);
                 this.Controls.Add(this.splitContainer1);
             }
-
-            _env = new LigraEnvironment();
         }
 
         private static SolusEngine _engine = new SolusEngine();
-
-        LigraEnvironment _env;
 
         ToolStripMenuItem _renderItemItem = new ToolStripMenuItem("Render Item");
         ToolStripMenuItem _propertiesItem = new ToolStripMenuItem("Properties");
@@ -41,9 +37,9 @@ namespace MetaphysicsIndustries.Ligra
 
             SetupContextMenu();
 
-            if (!_env.Variables.ContainsKey("t"))
+            if (!ligraControl1.Env.Variables.ContainsKey("t"))
             {
-                _env.Variables.Add("t", new Literal(0));
+                ligraControl1.Env.Variables.Add("t", new Literal(0));
             }
         }
 
@@ -149,13 +145,13 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItem_Click(object sender, EventArgs e)
         {
-            Commands.Command.ClearOutput(_env, ligraControl1);
+            Commands.Command.ClearOutput(ligraControl1.Env, ligraControl1);
         }
 
         private void timer1_Tick(object sender, EventArgs e)
         {
             float time = System.Environment.TickCount / 1000.0f;
-            _env.Variables["t"] = new Literal(time);
+            ligraControl1.Env.Variables["t"] = new Literal(time);
         }
 
         private void printDocument1_PrintPage(object sender, PrintPageEventArgs e)
@@ -194,14 +190,14 @@ namespace MetaphysicsIndustries.Ligra
                     {
                         ligraControl1.AddRenderItem(
                             new ErrorItem(input, ee2.Error, font, LBrush.Red,
-                                _env, ee2.Location));
+                                ligraControl1.Env, ee2.Location));
                     }
                     else
                     {
                         ligraControl1.AddRenderItem(
                             new ErrorItem(input,
                                 "There was an error: " + ee.ToString(), font,
-                                LBrush.Red, _env));
+                                LBrush.Red, ligraControl1.Env));
                     }
                 }
             }

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -48,7 +48,6 @@ namespace MetaphysicsIndustries.Ligra
                 _env.Variables.Add("t", new Literal(0));
             }
 
-            _env.Font = LFont.FromSwf(ligraControl1.Font);
             _env.ClearCanvas = ligraControl1.Invalidate;
         }
 

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -47,8 +47,6 @@ namespace MetaphysicsIndustries.Ligra
             {
                 _env.Variables.Add("t", new Literal(0));
             }
-
-            _env.ClearCanvas = ligraControl1.Invalidate;
         }
 
         private ToolStripMenuItem _clearItem = new ToolStripMenuItem("Clear");

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -131,7 +131,7 @@ namespace MetaphysicsIndustries.Ligra
 
         private RenderItem GetRenderItemFromPoint(PointF pt)
         {
-            return GetRenderItemInCollectionFromPoint(_env.RenderItems, pt);
+            return GetRenderItemInCollectionFromPoint(ligraControl1.RenderItems, pt);
         }
 
         private RenderItem GetRenderItemInCollectionFromPoint(IEnumerable<RenderItem> items, PointF pt)

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -26,8 +26,7 @@ namespace MetaphysicsIndustries.Ligra
                 this.Controls.Add(this.splitContainer1);
             }
 
-            _env = new LigraEnvironment(this.ligraControl1,
-                ligraControl1.Commands);
+            _env = new LigraEnvironment();
         }
 
         private static SolusEngine _engine = new SolusEngine();

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -154,7 +154,7 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItem_Click(object sender, EventArgs e)
         {
-            Commands.Command.ClearOutput(_env);
+            Commands.Command.ClearOutput(_env, ligraControl1);
         }
 
         private void timer1_Tick(object sender, EventArgs e)
@@ -190,7 +190,7 @@ namespace MetaphysicsIndustries.Ligra
             {
                 try
                 {
-                    ProcessInput(input);
+                    ProcessInput(input, ligraControl1);
                 }
                 catch (Exception ee)
                 {

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -218,36 +218,46 @@ namespace MetaphysicsIndustries.Ligra
         {
             if (e.KeyCode == Keys.Up)
             {
-                if (_env.History.Count > 0)
+                if (ligraControl1.History.Count > 0)
                 {
-                    if (_env.CurrentHistoryIndex < 0)
+                    if (ligraControl1.CurrentHistoryIndex < 0)
                     {
-                        _env.CurrentHistoryIndex = _env.History.Count - 1;
+                        ligraControl1.CurrentHistoryIndex = 
+                            ligraControl1.History.Count - 1;
                     }
                     else
                     {
-                        _env.CurrentHistoryIndex--;
-                        if (_env.CurrentHistoryIndex < 0) _env.CurrentHistoryIndex = 0;
+                        ligraControl1.CurrentHistoryIndex--;
+                        if (ligraControl1.CurrentHistoryIndex < 0)
+                            ligraControl1.CurrentHistoryIndex = 0;
                     }
 
-                    evalTextBox.Text = _env.History[_env.CurrentHistoryIndex];
+                    evalTextBox.Text =
+                        ligraControl1.History[
+                            ligraControl1.CurrentHistoryIndex];
                 }
             }
             else if (e.KeyCode == Keys.Down)
             {
-                if (_env.History.Count > 0)
+                if (ligraControl1.History.Count > 0)
                 {
-                    if (_env.CurrentHistoryIndex < 0)
+                    if (ligraControl1.CurrentHistoryIndex < 0)
                     {
-                        _env.CurrentHistoryIndex = _env.History.Count - 1;
+                        ligraControl1.CurrentHistoryIndex =
+                            ligraControl1.History.Count - 1;
                     }
                     else
                     {
-                        _env.CurrentHistoryIndex++;
-                        if (_env.CurrentHistoryIndex >= _env.History.Count) _env.CurrentHistoryIndex = _env.History.Count - 1;
+                        ligraControl1.CurrentHistoryIndex++;
+                        if (ligraControl1.CurrentHistoryIndex >=
+                            ligraControl1.History.Count)
+                            ligraControl1.CurrentHistoryIndex =
+                                ligraControl1.History.Count - 1;
                     }
 
-                    evalTextBox.Text = _env.History[_env.CurrentHistoryIndex];
+                    evalTextBox.Text =
+                        ligraControl1.History[
+                            ligraControl1.CurrentHistoryIndex];
                 }
             }
         }

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -26,7 +26,8 @@ namespace MetaphysicsIndustries.Ligra
                 this.Controls.Add(this.splitContainer1);
             }
 
-            _env = new LigraEnvironment(this.ligraControl1, _commands);
+            _env = new LigraEnvironment(this.ligraControl1,
+                ligraControl1.Commands);
         }
 
         private static SolusEngine _engine = new SolusEngine();
@@ -37,8 +38,6 @@ namespace MetaphysicsIndustries.Ligra
         ToolStripMenuItem _propertiesItem = new ToolStripMenuItem("Properties");
         private void LigraForm_Load(object sender, EventArgs e)
         {
-            InitializeCommands();
-
             evalTextBox.Focus();
 
             SetupContextMenu();

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -37,9 +37,9 @@ namespace MetaphysicsIndustries.Ligra
 
             SetupContextMenu();
 
-            if (!ligraControl1.Env.Variables.ContainsKey("t"))
+            if (!ligraControl1.Env.ContainsVariable("t"))
             {
-                ligraControl1.Env.Variables.Add("t", new Literal(0));
+                ligraControl1.Env.SetVariable("t", new Literal(0));
             }
         }
 
@@ -151,7 +151,7 @@ namespace MetaphysicsIndustries.Ligra
         private void timer1_Tick(object sender, EventArgs e)
         {
             float time = System.Environment.TickCount / 1000.0f;
-            ligraControl1.Env.Variables["t"] = new Literal(time);
+            ligraControl1.Env.SetVariable("t", new Literal(time));
         }
 
         private void printDocument1_PrintPage(object sender, PrintPageEventArgs e)

--- a/LigraForm.cs
+++ b/LigraForm.cs
@@ -190,14 +190,14 @@ namespace MetaphysicsIndustries.Ligra
                     {
                         ligraControl1.AddRenderItem(
                             new ErrorItem(input, ee2.Error, font, LBrush.Red,
-                                ligraControl1.Env, ee2.Location));
+                                ee2.Location));
                     }
                     else
                     {
                         ligraControl1.AddRenderItem(
                             new ErrorItem(input,
                                 "There was an error: " + ee.ToString(), font,
-                                LBrush.Red, ligraControl1.Env));
+                                LBrush.Red));
                     }
                 }
             }

--- a/LigraFormsControl.cs
+++ b/LigraFormsControl.cs
@@ -101,11 +101,12 @@ namespace MetaphysicsIndustries.Ligra
 
             if (_valueModulator != null)
             {
-                _env.Variables[_variable] = new Literal(_valueModulator((float)Value));
+                _env.SetVariable(_variable,
+                    new Literal(_valueModulator((float)Value)));
             }
             else
             {
-                _env.Variables[_variable] = new Literal(Value);
+                _env.SetVariable(_variable, new Literal(Value));
             }
 
             if (Parent != null)

--- a/LigraParser.cs
+++ b/LigraParser.cs
@@ -327,10 +327,8 @@ namespace MetaphysicsIndustries.Ligra
 
             // create the functino, with no expr
             var func = new UserDefinedFunction(funcname, args.ToArray(), null);
-            if (env2.Functions.ContainsKey(funcname))
-            {
-                env2.Functions.Remove(funcname);
-            }
+            if (env2.ContainsFunction(funcname))
+                env2.RemoveFunction(funcname);
             env2.AddFunction(func);
 
             // read the expr. this order of things allows for recursion

--- a/LigraParser.cs
+++ b/LigraParser.cs
@@ -4,8 +4,14 @@ using MetaphysicsIndustries.Giza;
 using System.Collections.Generic;
 using System.Linq;
 using MetaphysicsIndustries.Ligra.Commands;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
+using DeleteCommand = MetaphysicsIndustries.Ligra.Commands.DeleteCommand;
+using FuncAssignCommandData = MetaphysicsIndustries.Ligra.Commands.FuncAssignCommandData;
+using HelpCommandData = MetaphysicsIndustries.Ligra.Commands.HelpCommandData;
+using VarAssignCommandData = MetaphysicsIndustries.Ligra.Commands.VarAssignCommandData;
+using VarsCommand = MetaphysicsIndustries.Ligra.Commands.VarsCommand;
 
 namespace MetaphysicsIndustries.Ligra
 {
@@ -21,7 +27,8 @@ namespace MetaphysicsIndustries.Ligra
             _parser = new Parser(_grammar.def_commands);
         }
 
-        public new Command[] GetCommands(string input, SolusEnvironment env=null)
+        public new ICommandData[] GetCommands(string input,
+            SolusEnvironment env = null, CommandSet commandSet = null)
         {
             if (env == null)
             {
@@ -46,7 +53,7 @@ namespace MetaphysicsIndustries.Ligra
                     throw new InvalidOperationException("Error getting the expression", ex);
                 }
 
-                return new Command[] {new ExprCommand(expr)};
+                return new[] {new ExprCommandData(expr)};
             }
             if (spans.Length < 1)
             {
@@ -62,9 +69,9 @@ namespace MetaphysicsIndustries.Ligra
             return GetCommandsFromCommands(span, env);
         }
 
-        Command[] GetCommandsFromCommands(Span span, SolusEnvironment env)
+        ICommandData[] GetCommandsFromCommands(Span span, SolusEnvironment env)
         {
-            var commands = new List<Command>();
+            var commands = new List<ICommandData>();
 
             foreach (var sub in span.Subspans)
             {
@@ -76,7 +83,7 @@ namespace MetaphysicsIndustries.Ligra
             return commands.ToArray();
         }
 
-        public Command GetSingleCommand(string input, LigraEnvironment env)
+        public ICommandData GetSingleCommand(string input, LigraEnvironment env)
         {
             if (env == null) throw new ArgumentNullException(nameof(env));
             var errors1 = new List<Error>();
@@ -94,7 +101,7 @@ namespace MetaphysicsIndustries.Ligra
                     throw new InvalidOperationException();
                 }
 
-                return new ExprCommand(expr);
+                return new ExprCommandData(expr);
             }
             if (spans.Length < 1) throw new InvalidOperationException();
             if (spans.Length > 1) throw new InvalidOperationException();
@@ -104,7 +111,7 @@ namespace MetaphysicsIndustries.Ligra
             return GetCommandFromCommand(span, env);
         }
 
-        Command GetCommandFromCommand(Span span, SolusEnvironment env)
+        ICommandData GetCommandFromCommand(Span span, SolusEnvironment env)
         {
             var sub = span.Subspans[0];
             var def = sub.DefRef;
@@ -131,7 +138,7 @@ namespace MetaphysicsIndustries.Ligra
             }
             else if (def == _grammar.def_delete_002D_command)
             {
-                return GetDelCommandFromDelCommand(sub, env);
+                return new SimpleCommandData(DeleteCommand.Value);
             }
             else if (def == _grammar.def_var_002D_assign_002D_command)
             {
@@ -141,34 +148,42 @@ namespace MetaphysicsIndustries.Ligra
             {
                 return GetFuncAssignCommandFromFuncAssignCommand(sub, env);
             }
+            else if (def == _grammar.def_vars_002D_command)
+            {
+                return new SimpleCommandData(VarsCommand.Value);
+            }
             else
             {
                 throw new InvalidOperationException();
             }
         }
 
-        Command GetHelpCommandFromHelpCommand(Span span, SolusEnvironment env)
+        HelpCommandData GetHelpCommandFromHelpCommand(Span span,
+            SolusEnvironment env)
         {
             string topic = "help";
             if (span.Subspans.Count >= 2)
             {
-                topic = span.Subspans[1].Subspans[0].Value;
+                topic = span.Subspans[1].Value;
             }
 
-            return new HelpCommand(topic);
+            return new HelpCommandData(topic);
         }
 
-        Command GetClearCommandFromClearCommand(Span span, SolusEnvironment env)
+        ICommandData GetClearCommandFromClearCommand(Span span,
+            SolusEnvironment env)
+        {
+            return new SimpleCommandData(ClearCommand.Value);
+        }
+
+        ICommandData GetShowCommandFromShowCommand(Span span,
+            SolusEnvironment env)
         {
             throw new NotImplementedException();
         }
 
-        Command GetShowCommandFromShowCommand(Span span, SolusEnvironment env)
-        {
-            throw new NotImplementedException();
-        }
-
-        public PlotCommand GetPlotCommand(string input, LigraEnvironment env)
+        public PlotCommandData GetPlotCommand(string input,
+            LigraEnvironment env)
         {
             if (env == null) throw new ArgumentNullException(nameof(env));
             var errors1 = new List<Error>();
@@ -188,7 +203,8 @@ namespace MetaphysicsIndustries.Ligra
             return GetPlotCommandFromPlotCommand(span, env);
         }
 
-        PlotCommand GetPlotCommandFromPlotCommand(Span span, SolusEnvironment env)
+        PlotCommandData GetPlotCommandFromPlotCommand(Span span,
+            SolusEnvironment env)
         {
             var exprs = new List<Solus.Expressions.Expression>();
             var intervals = new List<VarInterval>();
@@ -205,10 +221,11 @@ namespace MetaphysicsIndustries.Ligra
                 }
             }
 
-            return new PlotCommand(exprs.ToArray(), intervals.ToArray());
+            return new PlotCommandData(exprs.ToArray(), intervals.ToArray());
         }
 
-        public VarInterval GetVarIntervalFromInterval(Span span, SolusEnvironment env)
+        public VarInterval GetVarIntervalFromInterval(Span span,
+            SolusEnvironment env)
         {
             if (span.Subspans[0].Node == _grammar.node_interval_0_varref)
             {
@@ -266,7 +283,8 @@ namespace MetaphysicsIndustries.Ligra
             }
         }
 
-        public PaintCommand GetPaintCommand(string input, LigraEnvironment env)
+        public PaintCommandData GetPaintCommand(string input,
+            LigraEnvironment env)
         {
             if (env == null) throw new ArgumentNullException(nameof(env));
             var errors1 = new List<Error>();
@@ -286,30 +304,34 @@ namespace MetaphysicsIndustries.Ligra
             return GetPaintCommandFromPaintCommand(span, env);
         }
 
-        PaintCommand GetPaintCommandFromPaintCommand(Span span, SolusEnvironment env)
+        PaintCommandData GetPaintCommandFromPaintCommand(Span span,
+            SolusEnvironment env)
         {
             var expr = GetExpressionFromExpr(span.Subspans[1], env);
             var interval1 = GetVarIntervalFromInterval(span.Subspans[3], env);
             var interval2 = GetVarIntervalFromInterval(span.Subspans[5], env);
 
-            return new PaintCommand(expr, interval1, interval2);
+            return new PaintCommandData(expr, interval1, interval2);
         }
 
-        Command GetDelCommandFromDelCommand(Span span, SolusEnvironment env)
+        ICommandData GetDelCommandFromDelCommand(Span span,
+            SolusEnvironment env)
         {
             throw new NotImplementedException();
         }
 
-        Command GetVarAssignCommandFromVarAssignCommand(Span span, SolusEnvironment env)
+        VarAssignCommandData GetVarAssignCommandFromVarAssignCommand(Span span,
+            SolusEnvironment env)
         {
             var varname = span.Subspans[0].Subspans[0].Value;
             var expr = GetExpressionFromExpr(span.Subspans[2], env);
             expr = expr.PreliminaryEval(env);
 
-            return new VarAssignCommand(varname, expr);
+            return new VarAssignCommandData(varname, expr);
         }
 
-        Command GetFuncAssignCommandFromFuncAssignCommand(Span span, SolusEnvironment env)
+        FuncAssignCommandData GetFuncAssignCommandFromFuncAssignCommand(
+            Span span, SolusEnvironment env)
         {
             var funcname = span.Subspans[0].Value;
 
@@ -323,9 +345,9 @@ namespace MetaphysicsIndustries.Ligra
                 }
             }
 
-            SolusEnvironment env2 = env.CreateChildEnvironment();
+            SolusEnvironment env2 = env.Clone();
 
-            // create the functino, with no expr
+            // create the function, with no expr
             var func = new UserDefinedFunction(funcname, args.ToArray(), null);
             if (env2.ContainsFunction(funcname))
                 env2.RemoveFunction(funcname);
@@ -335,7 +357,7 @@ namespace MetaphysicsIndustries.Ligra
             var expr = GetExpressionFromExpr(span.Subspans.Last(), env2);
             func.Expression = expr;
 
-            return new FuncAssignCommand(func);
+            return new FuncAssignCommandData(func);
         }
     }
 }

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Gtk;
+using MetaphysicsIndustries.Ligra.Commands;
 using MetaphysicsIndustries.Ligra.RenderItems;
+using MetaphysicsIndustries.Solus;
 
 namespace MetaphysicsIndustries.Ligra
 {
@@ -10,6 +13,7 @@ namespace MetaphysicsIndustries.Ligra
         public LigraWidget()
         {
             InitializeComponent();
+            Command.InitializeCommands(Commands);
         }
 
         void InitializeComponent()
@@ -27,6 +31,10 @@ namespace MetaphysicsIndustries.Ligra
         }
 
         public DrawSettings DrawSettings { get; } = new DrawSettings();
+
+        public Dictionary<string, Command> Commands { get; } =
+            new Dictionary<string, Command>(
+                StringComparer.InvariantCultureIgnoreCase);
 
         bool scrollToBottom = false;
 

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using Gtk;
 using MetaphysicsIndustries.Ligra.Commands;
+using MetaphysicsIndustries.Ligra.Expressions;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
 
 namespace MetaphysicsIndustries.Ligra
 {
@@ -14,6 +14,7 @@ namespace MetaphysicsIndustries.Ligra
         {
             InitializeComponent();
             Command.InitializeCommands(Commands);
+            Env.SetVariable("t", new TimeExpression());
         }
 
         void InitializeComponent()

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Gtk;
 using MetaphysicsIndustries.Ligra.RenderItems;
 
@@ -27,6 +26,8 @@ namespace MetaphysicsIndustries.Ligra
             _vbox.SizeAllocated += _vbox_SizeAllocated;
         }
 
+        public DrawSettings DrawSettings { get; } = new DrawSettings();
+
         bool scrollToBottom = false;
 
         private void _vbox_SizeAllocated(object o, SizeAllocatedArgs args)
@@ -53,6 +54,7 @@ namespace MetaphysicsIndustries.Ligra
             _items.Add(item);
             item.Container = this;
             var widget = item.GetAdapter();
+            ((RenderItemWidget) widget).Control = this;
             widget.ShowAll();
             _vbox.PackStart(widget, true, false, 3);
             _vbox.ShowAll();

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -83,5 +83,7 @@ namespace MetaphysicsIndustries.Ligra
         public int CurrentHistoryIndex { get; set; } = -1;
 
         public void ClearCanvas() => QueueDraw();
+
+        public LigraParser Parser { get; } = new LigraParser();
     }
 }

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -30,6 +30,8 @@ namespace MetaphysicsIndustries.Ligra
             _vbox.SizeAllocated += _vbox_SizeAllocated;
         }
 
+        public LigraEnvironment Env { get; } = new LigraEnvironment();
+
         public DrawSettings DrawSettings { get; } = new DrawSettings();
 
         public Dictionary<string, Command> Commands { get; } =

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -76,5 +76,8 @@ namespace MetaphysicsIndustries.Ligra
             window.TransientFor = (Gtk.Window)this.Toplevel;
             window.Modal = true;
         }
+
+        public IList<string> History { get; } = new List<string>();
+        public int CurrentHistoryIndex { get; set; } = -1;
     }
 }

--- a/LigraWidget.cs
+++ b/LigraWidget.cs
@@ -81,5 +81,7 @@ namespace MetaphysicsIndustries.Ligra
 
         public IList<string> History { get; } = new List<string>();
         public int CurrentHistoryIndex { get; set; } = -1;
+
+        public void ClearCanvas() => QueueDraw();
     }
 }

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -61,7 +61,7 @@ namespace MetaphysicsIndustries.Ligra
         private void timer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
             float time = System.Environment.TickCount / 1000.0f;
-            output.Env.Variables["t"] = new Literal(time);
+            output.Env.SetVariable("t", new Literal(time));
         }
 
         void EvaluateInput()
@@ -246,7 +246,7 @@ namespace MetaphysicsIndustries.Ligra
 
                 foreach (var command in commands)
                 {
-                    command.Execute(input, args, env, control);
+                    command.Execute(input, args, env, null, control);
                 }
             }
 

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -15,13 +15,8 @@ namespace MetaphysicsIndustries.Ligra
             : base(WindowType.Toplevel)
         {
             InitializeComponent();
-
-            timer = new System.Timers.Timer(16);
-            timer.Elapsed += timer_Elapsed;
-            timer.Enabled = true;
         }
 
-        System.Timers.Timer timer;
         Gtk.Button evalButton;
         Gtk.Entry input;
         LigraWidget output;
@@ -57,10 +52,6 @@ namespace MetaphysicsIndustries.Ligra
             hbox.PackEnd(evalButton, false, false, 0);
 
             SetupContextMenu();
-        }
-
-        private void timer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
-        {
         }
 
         void EvaluateInput()

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -14,8 +14,7 @@ namespace MetaphysicsIndustries.Ligra
             : base(WindowType.Toplevel)
         {
             InitializeComponent();
-            Commands.Command.InitializeCommands(availableCommands);
-            env = new LigraEnvironment(this.output, availableCommands);
+            env = new LigraEnvironment(this.output, output.Commands);
 
             timer = new System.Timers.Timer(16);
             timer.Elapsed += timer_Elapsed;
@@ -23,9 +22,6 @@ namespace MetaphysicsIndustries.Ligra
         }
 
         LigraEnvironment env;
-        Dictionary<string, Command> availableCommands =
-            new Dictionary<string, Command>(
-                StringComparer.InvariantCultureIgnoreCase);
 
         System.Timers.Timer timer;
         Gtk.Button evalButton;
@@ -79,7 +75,7 @@ namespace MetaphysicsIndustries.Ligra
             {
                 try
                 {
-                    LigraWindow.ProcessInput(s, env, availableCommands,
+                    LigraWindow.ProcessInput(s, env, output.Commands,
                         () => input.SelectRegion(0, input.Text.Length),
                         this.output);
                 }

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -14,14 +14,11 @@ namespace MetaphysicsIndustries.Ligra
             : base(WindowType.Toplevel)
         {
             InitializeComponent();
-            env = new LigraEnvironment();
 
             timer = new System.Timers.Timer(16);
             timer.Elapsed += timer_Elapsed;
             timer.Enabled = true;
         }
-
-        LigraEnvironment env;
 
         System.Timers.Timer timer;
         Gtk.Button evalButton;
@@ -64,7 +61,7 @@ namespace MetaphysicsIndustries.Ligra
         private void timer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
             float time = System.Environment.TickCount / 1000.0f;
-            env.Variables["t"] = new Literal(time);
+            output.Env.Variables["t"] = new Literal(time);
         }
 
         void EvaluateInput()
@@ -75,7 +72,7 @@ namespace MetaphysicsIndustries.Ligra
             {
                 try
                 {
-                    LigraWindow.ProcessInput(s, env, output.Commands,
+                    LigraWindow.ProcessInput(s, output.Env, output.Commands,
                         () => input.SelectRegion(0, input.Text.Length),
                         this.output);
                 }
@@ -84,13 +81,13 @@ namespace MetaphysicsIndustries.Ligra
                     output.AddRenderItem(
                         new ErrorItem(s, e.Error,
                             output.DrawSettings.Font,
-                            LBrush.Red, env, e.Location));
+                            LBrush.Red, output.Env, e.Location));
                 }
                 catch (Exception e)
                 {
                     output.AddRenderItem(
                         new ErrorItem(s, $"There was an error: {e}",
-                            output.DrawSettings.Font, LBrush.Red, env));
+                            output.DrawSettings.Font, LBrush.Red, output.Env));
                 }
             }
 
@@ -114,7 +111,7 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItems()
         {
-            Commands.Command.ClearOutput(env, output);
+            Commands.Command.ClearOutput(output.Env, output);
         }
 
         void DoRenderItemProperties()

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using Gtk;
 using MetaphysicsIndustries.Ligra.Commands;
 using MetaphysicsIndustries.Ligra.RenderItems;
-using MetaphysicsIndustries.Solus;
+using MetaphysicsIndustries.Solus.Commands;
 using MetaphysicsIndustries.Solus.Expressions;
+using Command = MetaphysicsIndustries.Ligra.Commands.Command;
 
 namespace MetaphysicsIndustries.Ligra
 {
@@ -215,6 +216,19 @@ namespace MetaphysicsIndustries.Ligra
             return availableCommands.ContainsKey(cmd);
         }
 
+        public static bool IsNonGrammarCommand(string cmd,
+            Dictionary<string, Command> availableCommands)
+        {
+            if (!availableCommands.ContainsKey(cmd)) return false;
+            var c = availableCommands[cmd];
+            if (c is CdCommand ||
+                c is HistoryCommand ||
+                c is ExampleCommand ||
+                c is Example2Command)
+                return true;
+            return false;
+        }
+
         public static void ProcessInput(string input, LigraEnvironment env,
             Dictionary<string, Command> availableCommands,
             System.Action selectAllInputText, ILigraUI control)
@@ -225,11 +239,14 @@ namespace MetaphysicsIndustries.Ligra
             {
                 string cmd = args[0].Trim().ToLower();
 
-                Command[] commands;
+                ICommandData[] commands;
 
-                if (IsCommand(cmd, availableCommands))
+                if (IsNonGrammarCommand(cmd, availableCommands))
                 {
-                    commands = new Command[] { availableCommands[cmd] };
+                    commands = new[]
+                    {
+                        new SimpleCommandData(availableCommands[cmd])
+                    };
                 }
                 else
                 {
@@ -246,7 +263,8 @@ namespace MetaphysicsIndustries.Ligra
 
                 foreach (var command in commands)
                 {
-                    command.Execute(input, args, env, null, control);
+                    command.Command.Execute(input, args, env, command,
+                        control);
                 }
             }
 

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -14,7 +14,7 @@ namespace MetaphysicsIndustries.Ligra
             : base(WindowType.Toplevel)
         {
             InitializeComponent();
-            env = new LigraEnvironment(this.output, output.Commands);
+            env = new LigraEnvironment();
 
             timer = new System.Timers.Timer(16);
             timer.Elapsed += timer_Elapsed;

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -240,13 +240,13 @@ namespace MetaphysicsIndustries.Ligra
                 }
                 else
                 {
-                    commands = env.Parser.GetCommands(input, env);
+                    commands = control.Parser.GetCommands(input, env);
                 }
 
                 var label = string.Format("$ {0}", input);
                 if (commands.Length == 1)
                 {
-                    label = commands[0].GetInputLabel(input, env);
+                    label = commands[0].GetInputLabel(input, env, control);
                 }
                 control.AddRenderItem(
                     new TextItem(env, label, control.DrawSettings.Font));

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -4,7 +4,6 @@ using Gtk;
 using MetaphysicsIndustries.Ligra.Commands;
 using MetaphysicsIndustries.Ligra.RenderItems;
 using MetaphysicsIndustries.Solus.Commands;
-using MetaphysicsIndustries.Solus.Expressions;
 using Command = MetaphysicsIndustries.Ligra.Commands.Command;
 
 namespace MetaphysicsIndustries.Ligra

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -17,8 +17,6 @@ namespace MetaphysicsIndustries.Ligra
             Commands.Command.InitializeCommands(availableCommands);
             env = new LigraEnvironment(this.output, availableCommands);
 
-            env.ClearCanvas = output.QueueDraw;
-
             timer = new System.Timers.Timer(16);
             timer.Elapsed += timer_Elapsed;
             timer.Enabled = true;

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -111,7 +111,7 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItems()
         {
-            Commands.Command.ClearOutput(output.Env, output);
+            Commands.Command.ClearOutput(output);
         }
 
         void DoRenderItemProperties()

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -84,7 +84,8 @@ namespace MetaphysicsIndustries.Ligra
                 try
                 {
                     LigraWindow.ProcessInput(s, env, availableCommands,
-                        () => input.SelectRegion(0, input.Text.Length));
+                        () => input.SelectRegion(0, input.Text.Length),
+                        this.output);
                 }
                 catch (Solus.Exceptions.ParseException e)
                 {
@@ -120,7 +121,7 @@ namespace MetaphysicsIndustries.Ligra
 
         void ClearItems()
         {
-            Commands.Command.ClearOutput(env);
+            Commands.Command.ClearOutput(env, output);
         }
 
         void DoRenderItemProperties()
@@ -226,7 +227,7 @@ namespace MetaphysicsIndustries.Ligra
 
         public static void ProcessInput(string input, LigraEnvironment env,
             Dictionary<string, Command> availableCommands,
-            System.Action selectAllInputText)
+            System.Action selectAllInputText, ILigraUI control)
         {
             var args = input.Split(new char[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -254,7 +255,7 @@ namespace MetaphysicsIndustries.Ligra
 
                 foreach (var command in commands)
                 {
-                    command.Execute(input, args, env);
+                    command.Execute(input, args, env, control);
                 }
             }
 

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -16,8 +16,6 @@ namespace MetaphysicsIndustries.Ligra
             InitializeComponent();
             Commands.Command.InitializeCommands(availableCommands);
             env = new LigraEnvironment(this.output, availableCommands);
-            env.Font = new LFont(LFont.Families.CourierNew, 12,
-                LFont.Styles.Regular);
 
             env.ClearCanvas = output.QueueDraw;
 
@@ -90,14 +88,15 @@ namespace MetaphysicsIndustries.Ligra
                 catch (Solus.Exceptions.ParseException e)
                 {
                     output.AddRenderItem(
-                        new ErrorItem(s, e.Error, env.Font, LBrush.Red, env,
-                        e.Location));
+                        new ErrorItem(s, e.Error,
+                            output.DrawSettings.Font,
+                            LBrush.Red, env, e.Location));
                 }
                 catch (Exception e)
                 {
                     output.AddRenderItem(
                         new ErrorItem(s, $"There was an error: {e}",
-                        env.Font, LBrush.Red, env));
+                            output.DrawSettings.Font, LBrush.Red, env));
                 }
             }
 
@@ -251,7 +250,8 @@ namespace MetaphysicsIndustries.Ligra
                 {
                     label = commands[0].GetInputLabel(input, env);
                 }
-                control.AddRenderItem(new TextItem(env, label, env.Font));
+                control.AddRenderItem(
+                    new TextItem(env, label, control.DrawSettings.Font));
 
                 foreach (var command in commands)
                 {

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -61,8 +61,6 @@ namespace MetaphysicsIndustries.Ligra
 
         private void timer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
-            float time = System.Environment.TickCount / 1000.0f;
-            output.Env.SetVariable("t", new Literal(time));
         }
 
         void EvaluateInput()

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -263,8 +263,11 @@ namespace MetaphysicsIndustries.Ligra
 
                 foreach (var command in commands)
                 {
-                    command.Command.Execute(input, args, env, command,
-                        control);
+                    var lcmd = (Command)command.Command;
+                    var env2 = env;
+                    if (!lcmd.ModifiesEnvironment)
+                        env2 = (LigraEnvironment)env.Clone();
+                    command.Execute(input, args, env2, control);
                 }
             }
 

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -259,12 +259,12 @@ namespace MetaphysicsIndustries.Ligra
                 }
             }
 
-            if (env.History.Count <= 0 || input != env.History[env.History.Count - 1])
+            if (control.History.Count <= 0 || input != control.History[control.History.Count - 1])
             {
-                env.History.Add(input);
+                control.History.Add(input);
             }
             selectAllInputText();
-            env.CurrentHistoryIndex = -1;
+            control.CurrentHistoryIndex = -1;
         }
     }
 }

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -201,7 +201,7 @@ namespace MetaphysicsIndustries.Ligra
 
         private RenderItem GetRenderItemFromPoint(Vector2 pt)
         {
-            return GetRenderItemInCollectionFromPoint(env.RenderItems, pt);
+            return GetRenderItemInCollectionFromPoint(output.RenderItems, pt);
         }
 
         private RenderItem GetRenderItemInCollectionFromPoint(

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -89,14 +89,14 @@ namespace MetaphysicsIndustries.Ligra
                 }
                 catch (Solus.Exceptions.ParseException e)
                 {
-                    env.AddRenderItem(
+                    output.AddRenderItem(
                         new ErrorItem(s, e.Error, env.Font, LBrush.Red, env,
                         e.Location));
                 }
                 catch (Exception e)
                 {
-                    env.AddRenderItem(
-                        new ErrorItem(s, "There was an error: " + e.ToString(),
+                    output.AddRenderItem(
+                        new ErrorItem(s, $"There was an error: {e}",
                         env.Font, LBrush.Red, env));
                 }
             }
@@ -251,7 +251,7 @@ namespace MetaphysicsIndustries.Ligra
                 {
                     label = commands[0].GetInputLabel(input, env);
                 }
-                env.AddRenderItem(new TextItem(env, label, env.Font));
+                control.AddRenderItem(new TextItem(env, label, env.Font));
 
                 foreach (var command in commands)
                 {

--- a/LigraWindow.cs
+++ b/LigraWindow.cs
@@ -81,13 +81,13 @@ namespace MetaphysicsIndustries.Ligra
                     output.AddRenderItem(
                         new ErrorItem(s, e.Error,
                             output.DrawSettings.Font,
-                            LBrush.Red, output.Env, e.Location));
+                            LBrush.Red, e.Location));
                 }
                 catch (Exception e)
                 {
                     output.AddRenderItem(
                         new ErrorItem(s, $"There was an error: {e}",
-                            output.DrawSettings.Font, LBrush.Red, output.Env));
+                            output.DrawSettings.Font, LBrush.Red));
                 }
             }
 
@@ -242,7 +242,7 @@ namespace MetaphysicsIndustries.Ligra
                     label = commands[0].GetInputLabel(input, env, control);
                 }
                 control.AddRenderItem(
-                    new TextItem(env, label, control.DrawSettings.Font));
+                    new TextItem(label, control.DrawSettings.Font));
 
                 foreach (var command in commands)
                 {

--- a/RenderItems/ApplyMatrixFilterItem.cs
+++ b/RenderItems/ApplyMatrixFilterItem.cs
@@ -21,7 +21,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         public string _caption;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             Matrix mat = _filter.Apply(_matrix);
             mat.ApplyToAll(AcuityEngine.ConvertFloatTo24g);
@@ -36,11 +37,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             rect.Size = new SizeF(GetImageWidth(mat), GetImageHeight(mat));
             g.DrawImage(image, rect);
 
-            SizeF textSize = g.MeasureString(_caption, _env.Font, GetImageWidth(mat));
+            SizeF textSize = g.MeasureString(_caption, drawSettings.Font,
+                GetImageWidth(mat));
             float textWidth = textSize.Width;
             float textHeight = textSize.Height;
             rect = new RectangleF(0, GetImageHeight(mat) + 2, textWidth, textHeight);
-            g.DrawString(_caption, _env.Font, LBrush.Black, rect);
+            g.DrawString(_caption, drawSettings.Font, LBrush.Black, rect);
 
             _lastSize = new Vector2(GetImageWidth(mat), GetImageHeight(mat));
 
@@ -51,9 +53,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             }
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
-            return _lastSize + new Vector2(0, g.MeasureString(_caption, _env.Font, (int)_lastSize.X).Y + 2);
+            return _lastSize + new Vector2(0,
+                g.MeasureString(_caption, drawSettings.Font,
+                    (int)_lastSize.X).Y + 2);
         }
 
         private int GetImageHeight(Matrix mat)

--- a/RenderItems/ApplyMatrixFilterItem.cs
+++ b/RenderItems/ApplyMatrixFilterItem.cs
@@ -22,7 +22,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public string _caption;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             Matrix mat = _filter.Apply(_matrix);
             mat.ApplyToAll(AcuityEngine.ConvertFloatTo24g);

--- a/RenderItems/ApplyMatrixFilterItem.cs
+++ b/RenderItems/ApplyMatrixFilterItem.cs
@@ -7,8 +7,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class ApplyMatrixFilterItem : RenderItem
     {
-        public ApplyMatrixFilterItem(Matrix matrix, MatrixFilter filter, string caption, LigraEnvironment env)
-            : base(env)
+        public ApplyMatrixFilterItem(Matrix matrix, MatrixFilter filter,
+            string caption)
         {
             _matrix = matrix.Clone();
             _filter = filter;

--- a/RenderItems/CodeItem.cs
+++ b/RenderItems/CodeItem.cs
@@ -2,8 +2,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class CodeItem : TextItem
     {
-        public CodeItem(LigraEnvironment env)
-            : base(env, Text)
+        public CodeItem()
+            : base(Text)
         {
         }
 

--- a/RenderItems/ControlItem.cs
+++ b/RenderItems/ControlItem.cs
@@ -2,8 +2,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     //public class ControlItem : RenderItem
     //{
-    //    public ControlItem(LigraFormsControl control, LigraControl parent, LigraEnvironment env)
-    //        : base(env)
+    //    public ControlItem(LigraFormsControl control, LigraControl parent)
     //    {
     //        if (control == null) { throw new ArgumentNullException("control"); }
     //        if (parent == null) { throw new ArgumentNullException("parent"); }

--- a/RenderItems/ErrorItem.cs
+++ b/RenderItems/ErrorItem.cs
@@ -22,7 +22,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public int _location;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             var font = _font;
 

--- a/RenderItems/ErrorItem.cs
+++ b/RenderItems/ErrorItem.cs
@@ -21,7 +21,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public LBrush _brush;
         public int _location;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             var font = _font;
 
@@ -48,7 +49,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             g.DrawString(_errorText, font, _brush, new Vector2(0, y));
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             float y = 0;
             var font = _font;

--- a/RenderItems/ErrorItem.cs
+++ b/RenderItems/ErrorItem.cs
@@ -1,12 +1,10 @@
-using MetaphysicsIndustries.Solus;
 
 namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class ErrorItem : RenderItem
     {
         public ErrorItem(string inputText, string errorText, LFont font,
-            LBrush brush, LigraEnvironment env, int location = -1)
-            : base(env)
+            LBrush brush, int location = -1)
         {
             _errorText = errorText;
             _inputText = inputText;

--- a/RenderItems/ExpressionItem.cs
+++ b/RenderItems/ExpressionItem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Functions;
 using MetaphysicsIndustries.Solus.Values;
@@ -10,8 +9,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class ExpressionItem : RenderItem
     {
-        public ExpressionItem(Expression expression, LPen pen, LFont font, LigraEnvironment env)
-            : base(env)
+        public ExpressionItem(Expression expression, LPen pen, LFont font)
         {
             _expression = expression;
             _pen = pen;
@@ -19,12 +17,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
         public ExpressionItem(Acuity.Vector vector, LPen pen, LFont font,
             LigraEnvironment env)
-            : this(GenerateVector(vector), pen, font, env)
+            : this(GenerateVector(vector), pen, font)
         {
         }
         public ExpressionItem(Acuity.Matrix matrix, LPen pen, LFont font,
             LigraEnvironment env)
-            : this(GenerateMatrix(matrix), pen, font, env)
+            : this(GenerateMatrix(matrix), pen, font)
         {
         }
 

--- a/RenderItems/ExpressionItem.cs
+++ b/RenderItems/ExpressionItem.cs
@@ -73,7 +73,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             var exprSize = CalcExpressionSize(Expression, g, Font);
             float xx = 0;

--- a/RenderItems/ExpressionItem.cs
+++ b/RenderItems/ExpressionItem.cs
@@ -72,14 +72,16 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             get { return _font; }
         }
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             var exprSize = CalcExpressionSize(Expression, g, Font);
             float xx = 0;
             RenderExpression(g, _expression, new Vector2(xx, 0), _pen, _pen.Brush, Font, false);
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             var exprSize = CalcExpressionSize(Expression, g, Font);
             return exprSize;

--- a/RenderItems/Graph3dItem.cs
+++ b/RenderItems/Graph3dItem.cs
@@ -16,7 +16,6 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             string independentVariableX,
             string independentVariableY,
             LigraEnvironment env)
-            : base(env)
         {
             _timer = new System.Timers.Timer(250);
             _timer.Elapsed += _timer_Elapsed;
@@ -33,6 +32,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             _yMax = yMax;
             _zMin = zMin;
             _zMax = zMax;
+
+            _env = env;
         }
 
         public static readonly SolusEngine _engine = new SolusEngine();
@@ -55,6 +56,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public float _yMax;
         public float _zMin;
         public float _zMax;
+        private readonly LigraEnvironment _env;
 
         int lastTime = Environment.TickCount;
         int numRenders = 0;

--- a/RenderItems/Graph3dItem.cs
+++ b/RenderItems/Graph3dItem.cs
@@ -62,7 +62,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         string fps = "";
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             var stime = Environment.TickCount;
 
@@ -75,7 +75,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 _expression,
                 _independentVariableX,
                 _independentVariableY,
-                env, true, drawSettings.Font);
+                _env, true, drawSettings.Font);
 
             var dtime = Environment.TickCount - stime;
             numTicks += dtime;

--- a/RenderItems/Graph3dItem.cs
+++ b/RenderItems/Graph3dItem.cs
@@ -204,14 +204,10 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             Expression prelimEval;
             Expression prelimEval2;
 
-            if (env.Variables.ContainsKey(independentVariableX))
-            {
-                env.Variables.Remove(independentVariableX);
-            }
-            if (env.Variables.ContainsKey(independentVariableY))
-            {
-                env.Variables.Remove(independentVariableY);
-            }
+            if (env.ContainsVariable(independentVariableX))
+                env.RemoveVariable(independentVariableX);
+            if (env.ContainsVariable(independentVariableY))
+                env.RemoveVariable(independentVariableY);
 
             prelimEval = _engine.PreliminaryEval(expr, env);
 
@@ -219,18 +215,16 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             {
                 x = xMin + i * deltaX;
 
-                env.Variables[independentVariableX] = new Literal(x);
-                if (env.Variables.ContainsKey(independentVariableY))
-                {
-                    env.Variables.Remove(independentVariableY);
-                }
+                env.SetVariable(independentVariableX, new Literal(x));
+                if (env.ContainsVariable(independentVariableY))
+                    env.RemoveVariable(independentVariableY);
 
                 prelimEval2 = _engine.PreliminaryEval(prelimEval, env);
 
                 for (j = 0; j < yValues; j++)
                 {
                     y = yMin + j * deltaY;
-                    env.Variables[independentVariableY] = new Literal(y);
+                    env.SetVariable(independentVariableY, new Literal(y));
 
                     z = prelimEval2.Eval(env).ToNumber().Value;
 

--- a/RenderItems/Graph3dItem.cs
+++ b/RenderItems/Graph3dItem.cs
@@ -61,7 +61,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         int numTicks = 0;
         string fps = "";
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             var stime = Environment.TickCount;
 
@@ -74,7 +75,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 _expression,
                 _independentVariableX,
                 _independentVariableY,
-                env, true, _env.Font);
+                env, true, drawSettings.Font);
 
             var dtime = Environment.TickCount - stime;
             numTicks += dtime;
@@ -89,10 +90,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 numRenders = 0;
             }
 
-            g.DrawString(fps, _env.Font, LBrush.Blue, new Vector2(0, 0));
+            g.DrawString(fps, drawSettings.Font, LBrush.Blue,
+                new Vector2(0, 0));
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return new Vector2(400, 400);
         }

--- a/RenderItems/GraphItem.cs
+++ b/RenderItems/GraphItem.cs
@@ -56,18 +56,20 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
     public class GraphItem : RenderItem
     {
-        public GraphItem(Expression expression, LPen pen, string independentVariable, SolusParser parser, LigraEnvironment env)
-            : this(parser, env, new GraphEntry(expression, pen, independentVariable))
+        public GraphItem(Expression expression, LPen pen,
+            string independentVariable, SolusParser parser,
+            LigraEnvironment env)
+            : this(parser, env,
+                new GraphEntry(expression, pen, independentVariable))
         {
         }
-
-        public GraphItem(SolusParser parser, LigraEnvironment env, params GraphEntry[] entries)
+        public GraphItem(SolusParser parser, LigraEnvironment env,
+            params GraphEntry[] entries)
             : this(parser, env, (IEnumerable<GraphEntry>)entries)
         {
         }
-
-        public GraphItem(SolusParser parser, LigraEnvironment env, IEnumerable<GraphEntry> entries)
-            : base(env)
+        public GraphItem(SolusParser parser, LigraEnvironment env,
+            IEnumerable<GraphEntry> entries)
         {
             _timer = new System.Timers.Timer(250);
             _timer.Elapsed += _timer_Elapsed;
@@ -80,6 +82,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             _maxY = 2;
             _minY = -2;
             _parser = parser;
+
+            _env = env;
         }
 
         public override Vector2? DefaultSize => new Vector2(400, 400);
@@ -96,6 +100,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public float _maxY;
         public float _minY;
         public SolusParser _parser;
+        private readonly LigraEnvironment _env;
 
         public List<GraphEntry> _entries = new List<GraphEntry>();
         //private SizeF _size = new SizeF(400, 400);

--- a/RenderItems/GraphItem.cs
+++ b/RenderItems/GraphItem.cs
@@ -100,7 +100,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public List<GraphEntry> _entries = new List<GraphEntry>();
         //private SizeF _size = new SizeF(400, 400);
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             g.DrawRectangle(LPen.Red, Rect.X, Rect.Y, Rect.Width, Rect.Height);
             bool first = true;
@@ -129,7 +130,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             }
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return Rect.Size.ToVector2();
         }

--- a/RenderItems/GraphItem.cs
+++ b/RenderItems/GraphItem.cs
@@ -210,7 +210,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 //}
             }
 
-            env.Variables[independentVariable] = new Literal(xMin);//+deltaX*50);
+            env.SetVariable(independentVariable, new Literal(xMin));
             //PointF lastPoint = new PointF(boundsInClient.Left, boundsInClient.Bottom - (Math.Max(Math.Min(_engine.Eval(expr, env).Value, yMax), yMin) - yMin) * deltaY);
 
             double vvalue = expr.Eval(env).ToNumber().Value;
@@ -227,7 +227,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             for (i = 0; i < boundsInClient.Width; i++)
             {
                 float x = xMin + deltaX * i;
-                env.Variables[independentVariable] = new Literal(x);
+                env.SetVariable(independentVariable, new Literal(x));
                 double value = expr.Eval(env).ToNumber().Value;
                 if (double.IsNaN(value))
                 {

--- a/RenderItems/GraphItem.cs
+++ b/RenderItems/GraphItem.cs
@@ -101,7 +101,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         //private SizeF _size = new SizeF(400, 400);
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             g.DrawRectangle(LPen.Red, Rect.X, Rect.Y, Rect.Width, Rect.Height);
             bool first = true;
@@ -116,7 +116,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                         entry.Pen, entry.Pen.Brush,
                         _minX, _maxX, _minY, _maxY,
                         ve.X, ve.Y,
-                        env, first);
+                        _env, first);
                 }
                 else
                 {
@@ -124,7 +124,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                         new RectangleF(location, Rect.Size),
                         entry.Pen, entry.Pen.Brush,
                         _minX, _maxX, _minY, _maxY,
-                        entry.Expression, entry.IndependentVariable, env, first);
+                        entry.Expression, entry.IndependentVariable, _env,
+                        first);
                 }
                 first = false;
             }

--- a/RenderItems/GraphMatrixItem.cs
+++ b/RenderItems/GraphMatrixItem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using MetaphysicsIndustries.Acuity;
 using MetaphysicsIndustries.Solus;
 using MetaphysicsIndustries.Solus.Expressions;
 using MetaphysicsIndustries.Solus.Values;
@@ -12,10 +11,10 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
     {
         public GraphMatrixItem(Acuity.Matrix matrix, string caption,
             LigraEnvironment env)
-            : base(env)
         {
             _matrix = matrix.Clone();
             _caption = caption;
+            _env = env;
         }
 
         private Acuity.Matrix _matrix;
@@ -25,6 +24,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         public string _caption;
+
+        private readonly LigraEnvironment _env;
 
         public MemoryImage _image = null;
 
@@ -61,6 +62,9 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 textHeight);
             g.DrawString(_caption, drawSettings.Font, LBrush.Black, rect);
         }
+
+        protected override void CollectVariableValuesFromEnv() =>
+            CollectVariableValues(_env);
 
         protected override Vector2 InternalCalcSize(IRenderer g,
             DrawSettings drawSettings)

--- a/RenderItems/GraphMatrixItem.cs
+++ b/RenderItems/GraphMatrixItem.cs
@@ -29,12 +29,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public MemoryImage _image = null;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             RectangleF boundsInClient = new RectangleF(0, 0,
                 Matrix.ColumnCount, Matrix.RowCount);
 
-            if (_image == null || HasChanged(env))
+            if (_image == null || HasChanged(_env))
             {
                 MemoryImage image =
                     GraphMatrixItem.RenderMatrixToMemoryImage(Matrix);

--- a/RenderItems/GraphMatrixItem.cs
+++ b/RenderItems/GraphMatrixItem.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public MemoryImage _image = null;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env)
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             RectangleF boundsInClient = new RectangleF(0, 0,
                 Matrix.ColumnCount, Matrix.RowCount);
@@ -53,19 +53,20 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 GetImageHeight());
             g.DrawImage(_image, rect);
 
-            SizeF textSize = g.MeasureString(_caption, _env.Font,
+            SizeF textSize = g.MeasureString(_caption, drawSettings.Font,
                 GetImageWidth());
             float textWidth = textSize.Width;
             float textHeight = textSize.Height;
             rect = new RectangleF(0, GetImageHeight() + 2, textWidth,
                 textHeight);
-            g.DrawString(_caption, _env.Font, LBrush.Black, rect);
+            g.DrawString(_caption, drawSettings.Font, LBrush.Black, rect);
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             var width = GetImageWidth();
-            var captionSize = g.MeasureString(_caption, _env.Font,
+            var captionSize = g.MeasureString(_caption, drawSettings.Font,
                 GetImageWidth());
 
             return new Vector2(

--- a/RenderItems/GraphVectorItem.cs
+++ b/RenderItems/GraphVectorItem.cs
@@ -29,7 +29,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         //MemoryImage _image = null;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             RectangleF boundsInClient = new RectangleF(new PointF(0, 0),
                 InternalCalcSize(g, drawSettings));

--- a/RenderItems/GraphVectorItem.cs
+++ b/RenderItems/GraphVectorItem.cs
@@ -28,27 +28,34 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         //MemoryImage _image = null;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
-            RectangleF boundsInClient = new RectangleF(new PointF(0, 0), InternalCalcSize(g));
+            RectangleF boundsInClient = new RectangleF(new PointF(0, 0),
+                InternalCalcSize(g, drawSettings));
             boundsInClient.Height = 276;
 
             RenderVector(g, boundsInClient, LPen.Blue, LBrush.Blue, _vector, true);
 
-            RectangleF rect = new RectangleF(10, 276, _vector.Length, g.MeasureString(_caption, _env.Font).Y);
-            g.DrawString(_caption, _env.Font, LBrush.Black, rect);
+            var rect = new RectangleF(10, 276, _vector.Length,
+                g.MeasureString(_caption, drawSettings.Font).Y);
+            g.DrawString(_caption, drawSettings.Font, LBrush.Black, rect);
 
             //g.DrawImage(_image.Bitmap, boundsInClient);
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             double x = Math.Log(_vector.Length, 2);
             if (x < 8)
             {
                 return new Vector2(276, 276);
             }
-            return new Vector2(_vector.Length + 20, 296 + g.MeasureString(_caption, _env.Font, _vector.Length).Y);
+            return new Vector2(
+                _vector.Length + 20,
+                296 + g.MeasureString(_caption, drawSettings.Font,
+                    _vector.Length).Y);
         }
 
         protected override void AddVariablesForValueCollection(HashSet<string> vars)

--- a/RenderItems/GraphVectorItem.cs
+++ b/RenderItems/GraphVectorItem.cs
@@ -10,9 +10,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class GraphVectorItem : RenderItem
     {
-        public GraphVectorItem(Acuity.Vector vector, string caption,
-            LigraEnvironment env)
-            : base(env)
+        public GraphVectorItem(Acuity.Vector vector, string caption)
         {
             _vector = vector.Clone();
             _caption = caption;

--- a/RenderItems/HelpItem.cs
+++ b/RenderItems/HelpItem.cs
@@ -14,12 +14,14 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public readonly string _text;
         public readonly LFont _font;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             g.DrawString(_text, _font, LBrush.Magenta, new Vector2(0, 0));
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return g.MeasureString(_text, _font);//, 500);
         }

--- a/RenderItems/HelpItem.cs
+++ b/RenderItems/HelpItem.cs
@@ -4,8 +4,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class HelpItem : RenderItem
     {
-        public HelpItem(LFont font, LigraEnvironment env, string text)
-            : base(env)
+        public HelpItem(LFont font, string text)
         {
             _font = font;
             _text = text;

--- a/RenderItems/HelpItem.cs
+++ b/RenderItems/HelpItem.cs
@@ -15,7 +15,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public readonly LFont _font;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             g.DrawString(_text, _font, LBrush.Magenta, new Vector2(0, 0));
         }

--- a/RenderItems/InfoItem.cs
+++ b/RenderItems/InfoItem.cs
@@ -14,12 +14,14 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public string _text;
         public LFont _font;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             g.DrawString(_text, _font, LBrush.Black, new Vector2(0, 0));
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return g.MeasureString(_text, _font);
         }

--- a/RenderItems/InfoItem.cs
+++ b/RenderItems/InfoItem.cs
@@ -15,7 +15,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public LFont _font;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             g.DrawString(_text, _font, LBrush.Black, new Vector2(0, 0));
         }

--- a/RenderItems/InfoItem.cs
+++ b/RenderItems/InfoItem.cs
@@ -4,8 +4,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class InfoItem : RenderItem
     {
-        public InfoItem(string text, LFont font, LigraEnvironment env)
-            : base(env)
+        public InfoItem(string text, LFont font)
         {
             _text = text;
             _font = font;

--- a/RenderItems/IntroItem.cs
+++ b/RenderItems/IntroItem.cs
@@ -4,8 +4,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class IntroItem : TextItem
     {
-        public IntroItem(LigraEnvironment env)
-            : base(env, IntroText)
+        public IntroItem()
+            : base(IntroText)
         {
         }
 

--- a/RenderItems/MathPaintItem.cs
+++ b/RenderItems/MathPaintItem.cs
@@ -84,13 +84,13 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         System.Timers.Timer _timer;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             RectangleF boundsInClient = new RectangleF(0, 0, _width, _height);
 
-            if (_image == null || HasChanged(env))
+            if (_image == null || HasChanged(_env))
             {
-                RenderMathPaintToMemoryImage(env);
+                RenderMathPaintToMemoryImage(_env);
             }
 
             ((GtkRenderer) g).DrawImage(_data, boundsInClient);

--- a/RenderItems/MathPaintItem.cs
+++ b/RenderItems/MathPaintItem.cs
@@ -64,11 +64,11 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             _data = new GtkRenderer.GtkDrawImageData(_image);
         }
         protected MathPaintItem(LigraEnvironment env)
-            : base(env)
         {
             _timer = new System.Timers.Timer(250);
             _timer.Elapsed += _timer_Elapsed;
             _timer.Enabled = true;
+            _env = env;
         }
 
         public Expression _expression;
@@ -83,6 +83,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         System.Timers.Timer _timer;
 
+        private readonly LigraEnvironment _env;
+
         protected override void InternalRender(IRenderer g,
             DrawSettings drawSettings)
         {
@@ -95,6 +97,9 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
             ((GtkRenderer) g).DrawImage(_data, boundsInClient);
         }
+
+        protected override void CollectVariableValuesFromEnv() =>
+            CollectVariableValues(_env);
 
         public void RenderMathPaintToMemoryImage(SolusEnvironment env)
         {

--- a/RenderItems/MathPaintItem.cs
+++ b/RenderItems/MathPaintItem.cs
@@ -83,7 +83,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         System.Timers.Timer _timer;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             RectangleF boundsInClient = new RectangleF(0, 0, _width, _height);
 
@@ -120,7 +121,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             GatherVariablesForValueCollection(vars, _expression);
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return new Vector2(_width, _height);
         }

--- a/RenderItems/MathPaintItem.cs
+++ b/RenderItems/MathPaintItem.cs
@@ -175,14 +175,10 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             Expression prelimEval1;
             Expression prelimEval2;
 
-            if (env.Variables.ContainsKey(independentVariableX))
-            {
-                env.Variables.Remove(independentVariableX);
-            }
-            if (env.Variables.ContainsKey(independentVariableY))
-            {
-                env.Variables.Remove(independentVariableY);
-            }
+            if (env.ContainsVariable(independentVariableX))
+                env.RemoveVariable(independentVariableX);
+            if (env.ContainsVariable(independentVariableY))
+                env.RemoveVariable(independentVariableY);
 
             prelimEval1 = _engine.PreliminaryEval(expression, env);
 
@@ -194,17 +190,15 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
             for (i = 0; i < xValues; i++)
             {
-                env.Variables[independentVariableX] = new Literal(i);
-                if (env.Variables.ContainsKey(independentVariableY))
-                {
-                    env.Variables.Remove(independentVariableY);
-                }
+                env.SetVariable(independentVariableX, new Literal(i));
+                if (env.ContainsVariable(independentVariableY))
+                    env.RemoveVariable(independentVariableY);
 
                 prelimEval2 = _engine.PreliminaryEval(prelimEval1, env);
 
                 for (j = 0; j < yValues; j++)
                 {
-                    env.Variables[independentVariableY] = new Literal(j);
+                    env.SetVariable(independentVariableY, new Literal(j));
 
                     z = prelimEval2.Eval(env).ToNumber().Value;
 

--- a/RenderItems/RenderItem.cs
+++ b/RenderItems/RenderItem.cs
@@ -12,11 +12,6 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
     {
         private static SolusEngine _engine = new SolusEngine();
 
-        protected RenderItem(LigraEnvironment env)
-        {
-            _env = env;
-        }
-
         protected abstract void InternalRender(IRenderer g,
             DrawSettings drawSettings);
         protected abstract Vector2 InternalCalcSize(IRenderer g,
@@ -26,7 +21,6 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public SizeF _errorSize = new SizeF(0, 0);
         public bool _changeSize = true;
 
-        public readonly LigraEnvironment _env;
         public ILigraUI Container { get; set; }
 
         public void Render(IRenderer g, DrawSettings drawSettings)
@@ -39,7 +33,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 {
                     InternalRender(g, drawSettings);
 
-                    CollectVariableValues(_env);
+                    CollectVariableValuesFromEnv();
                 }
                 else
                 {
@@ -81,6 +75,11 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 {
                 }
             }
+        }
+
+        protected virtual void CollectVariableValuesFromEnv()
+        {
+            // e.g. CollectVariableValues(_env);
         }
 
         public void CollectVariableValues(SolusEnvironment env)

--- a/RenderItems/RenderItem.cs
+++ b/RenderItems/RenderItem.cs
@@ -18,7 +18,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         protected abstract void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings);
+            DrawSettings drawSettings);
         protected abstract Vector2 InternalCalcSize(IRenderer g,
             DrawSettings drawSettings);
 
@@ -37,7 +37,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             {
                 if (string.IsNullOrEmpty(_error))
                 {
-                    InternalRender(g, _env, drawSettings);
+                    InternalRender(g, drawSettings);
 
                     CollectVariableValues(_env);
                 }

--- a/RenderItems/RenderItem.cs
+++ b/RenderItems/RenderItem.cs
@@ -93,7 +93,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             _varValues.Clear();
             foreach (string var in vars)
             {
-                _varValues[var] = env.Variables[var];
+                _varValues[var] = env.GetVariable(var);
             }
         }
 
@@ -115,9 +115,9 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             //return true;
             foreach (string var in _varValues.Keys)
             {
-                if (!env.Variables.ContainsKey(var)) { return true; }
+                if (!env.ContainsVariable(var)) return true;
 
-                if (env.Variables[var] != _varValues[var]) { return true; }
+                if (env.GetVariable(var) != _varValues[var]) return true;
             }
 
             return false;

--- a/RenderItems/RenderItem.cs
+++ b/RenderItems/RenderItem.cs
@@ -17,8 +17,10 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             _env = env;
         }
 
-        protected abstract void InternalRender(IRenderer g, SolusEnvironment env);
-        protected abstract Vector2 InternalCalcSize(IRenderer g);
+        protected abstract void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings);
+        protected abstract Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings);
 
         public string _error = string.Empty;
         public SizeF _errorSize = new SizeF(0, 0);
@@ -27,7 +29,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public readonly LigraEnvironment _env;
         public ILigraUI Container { get; set; }
 
-        public void Render(IRenderer g, LFont font)
+        public void Render(IRenderer g, DrawSettings drawSettings)
         {
             var red = LBrush.Red;
 
@@ -35,13 +37,13 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             {
                 if (string.IsNullOrEmpty(_error))
                 {
-                    InternalRender(g, _env);
+                    InternalRender(g, _env, drawSettings);
 
                     CollectVariableValues(_env);
                 }
                 else
                 {
-                    g.DrawString(_error, font, red,
+                    g.DrawString(_error, drawSettings.Font, red,
                         new Vector2(0, 0));
                 }
             }
@@ -51,9 +53,9 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                          "the item: \r\n" + ex.ToString();
                 _changeSize = true;
 
-                g.DrawString(_error, font, red,
+                g.DrawString(_error, drawSettings.Font, red,
                     new Vector2(0, 0));
-                _errorSize = g.MeasureString(_error, font);
+                _errorSize = g.MeasureString(_error, drawSettings.Font);
 
                 g.DrawRectangle(LPen.Red, 0, 0, _errorSize.Width,
                     _errorSize.Height);
@@ -67,7 +69,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
                 {
                     if (string.IsNullOrEmpty(_error))
                     {
-                        Size = Size.Truncate(InternalCalcSize(g));
+                        Size = Size.Truncate(
+                            InternalCalcSize(g, drawSettings));
                     }
                     else
                     {
@@ -169,9 +172,9 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             return new RenderItemWidget(this);
         }
         
-        public Vector2 CalculateSize(IRenderer g)
+        public Vector2 CalculateSize(IRenderer g, DrawSettings drawSettings)
         {
-            return InternalCalcSize(g);
+            return InternalCalcSize(g, drawSettings);
         }
 
         public virtual Vector2? DefaultSize => null;
@@ -221,11 +224,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         protected readonly RenderItem _owner;
+        public ILigraUI Control;
 
         private void RenderItemWidget_Drawn(object o, DrawnArgs args)
         {
             var g = new GtkRenderer(args.Cr, this);
-            _owner.Render(g, _owner._env.Font);
+            _owner.Render(g, Control.DrawSettings);
         }
     }
 
@@ -239,14 +243,14 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         protected readonly RenderItem _owner;
+        public ILigraUI Control;
 
         protected override void OnPaint(PaintEventArgs e)
         {
             base.OnPaint(e);
 
             var g = new SwfRenderer(e.Graphics);
-            var font = LFont.FromSwf(this.Font);
-            _owner.Render(g, font);
+            _owner.Render(g, Control.DrawSettings);
         }
 
         public RectangleF Rect // Size, Height, Width, Bounds, ClientRectangle, etc.

--- a/RenderItems/RenderItemContainer.cs
+++ b/RenderItems/RenderItemContainer.cs
@@ -16,7 +16,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public readonly string _caption;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             var font2 = new LFont(
                 drawSettings.Font.Family,

--- a/RenderItems/RenderItemContainer.cs
+++ b/RenderItems/RenderItemContainer.cs
@@ -7,8 +7,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class RenderItemContainer : RenderItem
     {
-        public RenderItemContainer(string caption, LigraEnvironment env)
-            : base(env)
+        public RenderItemContainer(string caption)
         {
             _caption = caption;
         }

--- a/RenderItems/RenderItemContainer.cs
+++ b/RenderItems/RenderItemContainer.cs
@@ -15,16 +15,19 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         public readonly string _caption;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
-            var font2 = new LFont(_env.Font.Family, _env.Font.Size * 2,
+            var font2 = new LFont(
+                drawSettings.Font.Family,
+                drawSettings.Font.Size * 2,
                 LFont.Styles.Bold);
 
             float width = this.Container.ClientSize.X - 20;
             float height = g.MeasureString(_caption, font2, (int)width).Y;
 
             g.DrawString(_caption, font2, LBrush.Black, new Vector2(2, 2));
-            var size1 = InternalCalcSize(g);
+            var size1 = InternalCalcSize(g, drawSettings);
             g.DrawRectangle(LPen.Black, 0, 0, size1.X, size1.Y - 250);
 
             float x = 20;
@@ -32,7 +35,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             float maxCurrentHeight = 0;
             foreach (RenderItem ri in Items)
             {
-                var size = ri.CalculateSize(g);
+                var size = ri.CalculateSize(g, drawSettings);
                 if (x + size.X > width)
                 {
                     height += maxCurrentHeight;
@@ -56,9 +59,12 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             get { return _items; }
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
-            var font2 = new LFont(_env.Font.Family, _env.Font.Size * 2,
+            var font2 = new LFont(
+                drawSettings.Font.Family,
+                drawSettings.Font.Size * 2,
                 LFont.Styles.Bold);
 
             float width = this.Container.ClientSize.X - 20;

--- a/RenderItems/SpacerItem.cs
+++ b/RenderItems/SpacerItem.cs
@@ -18,7 +18,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         public readonly Vector2 _size;
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
         }
 

--- a/RenderItems/SpacerItem.cs
+++ b/RenderItems/SpacerItem.cs
@@ -17,11 +17,13 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 
         public readonly Vector2 _size;
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return _size;
         }

--- a/RenderItems/SpacerItem.cs
+++ b/RenderItems/SpacerItem.cs
@@ -4,14 +4,13 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class SpacerItem : RenderItem
     {
-        public SpacerItem(Vector2 size, LigraEnvironment env)
-            : base(env)
+        public SpacerItem(Vector2 size)
         {
             _size = size;
         }
 
-        public SpacerItem(float width, float height, LigraEnvironment env)
-            : this(new Vector2(width, height), env)
+        public SpacerItem(float width, float height)
+            : this(new Vector2(width, height))
         {
         }
 

--- a/RenderItems/TextItem.cs
+++ b/RenderItems/TextItem.cs
@@ -5,8 +5,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
 {
     public class TextItem : RenderItem
     {
-        public TextItem(LigraEnvironment env, string text="", LFont font=null)
-            : base(env)
+        public TextItem(string text="", LFont font=null)
         {
             _text = text;
             _font = font;

--- a/RenderItems/TextItem.cs
+++ b/RenderItems/TextItem.cs
@@ -24,7 +24,7 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
         }
 
         protected override void InternalRender(IRenderer g,
-            SolusEnvironment env, DrawSettings drawSettings)
+            DrawSettings drawSettings)
         {
             RectangleF rect = new RectangleF(new PointF(0, 0),
                 InternalCalcSize(g, drawSettings));

--- a/RenderItems/TextItem.cs
+++ b/RenderItems/TextItem.cs
@@ -23,10 +23,11 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             }
         }
 
-        protected override void InternalRender(IRenderer g, SolusEnvironment env)
+        protected override void InternalRender(IRenderer g,
+            SolusEnvironment env, DrawSettings drawSettings)
         {
             RectangleF rect = new RectangleF(new PointF(0, 0),
-                InternalCalcSize(g));
+                InternalCalcSize(g, drawSettings));
 
             StringFormat fmt = Format;
             if (fmt == null)
@@ -39,7 +40,8 @@ namespace MetaphysicsIndustries.Ligra.RenderItems
             }
         }
 
-        protected override Vector2 InternalCalcSize(IRenderer g)
+        protected override Vector2 InternalCalcSize(IRenderer g,
+            DrawSettings drawSettings)
         {
             return g.MeasureString(_text, _font, Container.ClientSize.X - 25);
         }

--- a/packages.config
+++ b/packages.config
@@ -8,6 +8,6 @@
   <package id="GtkSharp" version="3.22.25.128" targetFramework="net40" />
   <package id="MetaphysicsIndustries.Acuity" version="0.1.0" targetFramework="net472" />
   <package id="MetaphysicsIndustries.Giza" version="0.2.0" targetFramework="net472" />
-  <package id="MetaphysicsIndustries.Solus" version="0.4.0" targetFramework="net472" />
+  <package id="MetaphysicsIndustries.Solus" version="0.5.0" targetFramework="net472" />
   <package id="PangoSharp" version="3.22.25.128" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This PR re-works some of the internals relating to commands and the environment. It removes all the pieces of `LigraEnvironment` and puts them in in more appropriate places. It updates the `Solus` dependency to `0.5`, which has its own changes for commands and environment. It uses command data classes, so that command objects don't have to be instantiated more than once, and never within the parser. Moreover, this PR uses cloned environments, so that each render item is isolated from the others. This way, a change to a variable would not affect a previous plot that relied on the value of that variable.